### PR TITLE
chore: Adds regex property to TextInput

### DIFF
--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "3.1.4",
+    "version": "3.1.5",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/src/doist-card/inputs.ts
+++ b/packages/ui-extensions-core/src/doist-card/inputs.ts
@@ -45,6 +45,9 @@ export class TextInput extends Input {
     @JsonProperty()
     inlineAction?: Action
 
+    @JsonProperty()
+    regex?: string
+
     getActionById(id: string): Action | undefined {
         let result = super.getActionById(id)
 


### PR DESCRIPTION
Implements the `regex` property that has been added to the DoistCard spec for 0.6.

The property already exists on adaptive cards, we are now making it available for our own spec. The property itself was already part of the [json schema](https://github.com/Doist/ui-extensions/blob/main/schemas/0.6/doist-card.json#L809-L812).