### PR TITLE
chore (ui-extensions-react): Bump React to v17 and Reactist to v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34341,10 +34341,10 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^11.0.0",
+                "@doist/reactist": "^12.0.0",
                 "@doist/ui-extensions-core": "^3.1.4",
                 "adaptivecards": "^2.9.0",
-                "react": ">=16"
+                "react": ">=17"
             }
         },
         "packages/ui-extensions-react/node_modules/@babel/eslint-parser": {
@@ -36466,7 +36466,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
-                "@doist/reactist": "*",
+                "@doist/reactist": "^12.0.1",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27819,6 +27819,7 @@
         "node_modules/react": {
             "version": "16.14.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -27925,6 +27926,7 @@
         "node_modules/react-dom": {
             "version": "16.14.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -28140,6 +28142,19 @@
                 "@babel/runtime": "^7.7.6"
             }
         },
+        "node_modules/react-shallow-renderer": {
+            "version": "16.15.0",
+            "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+            "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+            "dev": true,
+            "dependencies": {
+                "object-assign": "^4.1.1",
+                "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/react-sizeme": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-3.0.2.tgz",
@@ -28172,6 +28187,7 @@
             "version": "16.14.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "object-assign": "^4.1.1",
                 "prop-types": "^15.6.2",
@@ -30187,6 +30203,7 @@
         "node_modules/scheduler": {
             "version": "0.19.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -34334,10 +34351,10 @@
                 "@testing-library/react-hooks": "^3.3.0",
                 "eslint-config-react-app": "^7.0.0",
                 "msw": "^0.36.8",
-                "react": "^16.14.0",
-                "react-dom": "^16.14.0",
-                "react-is": "^16.13.1",
-                "react-test-renderer": "^16.13.1"
+                "react": "^17.0.2",
+                "react-dom": "^17.0.2",
+                "react-is": "^17.0.2",
+                "react-test-renderer": "^17.0.2"
             },
             "engines": {
                 "node": ">=16"
@@ -35099,6 +35116,54 @@
                 "node": ">= 0.8.0"
             }
         },
+        "packages/ui-extensions-react/node_modules/react": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+            "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+            "dev": true,
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "packages/ui-extensions-react/node_modules/react-dom": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+            "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+            "dev": true,
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "scheduler": "^0.20.2"
+            },
+            "peerDependencies": {
+                "react": "17.0.2"
+            }
+        },
+        "packages/ui-extensions-react/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true
+        },
+        "packages/ui-extensions-react/node_modules/react-test-renderer": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+            "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+            "dev": true,
+            "dependencies": {
+                "object-assign": "^4.1.1",
+                "react-is": "^17.0.2",
+                "react-shallow-renderer": "^16.13.1",
+                "scheduler": "^0.20.2"
+            },
+            "peerDependencies": {
+                "react": "17.0.2"
+            }
+        },
         "packages/ui-extensions-react/node_modules/resolve": {
             "version": "2.0.0-next.3",
             "dev": true,
@@ -35109,6 +35174,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "packages/ui-extensions-react/node_modules/scheduler": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+            "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+            "dev": true,
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
             }
         },
         "packages/ui-extensions-react/node_modules/strip-ansi": {
@@ -36363,10 +36438,10 @@
                 "dayjs": "^1.9.1",
                 "eslint-config-react-app": "^7.0.0",
                 "msw": "^0.36.8",
-                "react": "^16.14.0",
-                "react-dom": "^16.14.0",
-                "react-is": "^16.13.1",
-                "react-test-renderer": "^16.13.1"
+                "react": "^17.0.0",
+                "react-dom": "^17.0.0",
+                "react-is": "^17.0.0",
+                "react-test-renderer": "^17.0.0"
             },
             "dependencies": {
                 "@babel/eslint-parser": {
@@ -36813,12 +36888,61 @@
                     "dev": true,
                     "peer": true
                 },
+                "react": {
+                    "version": "17.0.2",
+                    "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+                    "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                },
+                "react-dom": {
+                    "version": "17.0.2",
+                    "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+                    "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1",
+                        "scheduler": "^0.20.2"
+                    }
+                },
+                "react-is": {
+                    "version": "17.0.2",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+                    "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+                    "dev": true
+                },
+                "react-test-renderer": {
+                    "version": "17.0.2",
+                    "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+                    "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+                    "dev": true,
+                    "requires": {
+                        "object-assign": "^4.1.1",
+                        "react-is": "^17.0.2",
+                        "react-shallow-renderer": "^16.13.1",
+                        "scheduler": "^0.20.2"
+                    }
+                },
                 "resolve": {
                     "version": "2.0.0-next.3",
                     "dev": true,
                     "requires": {
                         "is-core-module": "^2.2.0",
                         "path-parse": "^1.0.6"
+                    }
+                },
+                "scheduler": {
+                    "version": "0.20.2",
+                    "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+                    "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
                     }
                 },
                 "strip-ansi": {
@@ -54778,6 +54902,7 @@
         },
         "react": {
             "version": "16.14.0",
+            "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -54854,6 +54979,7 @@
         },
         "react-dom": {
             "version": "16.14.0",
+            "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -55011,6 +55137,16 @@
                 }
             }
         },
+        "react-shallow-renderer": {
+            "version": "16.15.0",
+            "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+            "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.1",
+                "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "react-sizeme": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-3.0.2.tgz",
@@ -55039,6 +55175,7 @@
         "react-test-renderer": {
             "version": "16.14.0",
             "dev": true,
+            "peer": true,
             "requires": {
                 "object-assign": "^4.1.1",
                 "prop-types": "^15.6.2",
@@ -56369,6 +56506,7 @@
         },
         "scheduler": {
             "version": "0.19.1",
+            "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1817,6 +1817,7 @@
         },
         "node_modules/@babel/runtime": {
             "version": "7.16.7",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "regenerator-runtime": "^0.13.4"
@@ -1939,69 +1940,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "prettier": "^2.0.0"
-            }
-        },
-        "node_modules/@doist/reactist": {
-            "version": "11.0.0",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@reach/dialog": "^0.16.0",
-                "@types/testing-library__jest-dom": "^5.14.1",
-                "dayjs": "^1.8.10",
-                "patch-package": "^6.4.6",
-                "react-focus-lock": "^2.5.2",
-                "react-keyed-flatten-children": "^1.3.0",
-                "react-markdown": "^5.0.3",
-                "reakit": "1.3.0"
-            },
-            "engines": {
-                "node": "<=16.10.0",
-                "npm": "^7.0.0"
-            },
-            "peerDependencies": {
-                "classnames": "^2.2.5",
-                "prop-types": "^15.6.2",
-                "react": "^15.5.4 || ^16.2.0 || ^17.0.0",
-                "react-dom": "^15.5.4 || ^16.2.0 || ^17.0.0"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/react-markdown": {
-            "version": "5.0.3",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/mdast": "^3.0.3",
-                "@types/unist": "^2.0.3",
-                "html-to-react": "^1.3.4",
-                "mdast-add-list-metadata": "1.0.1",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.6",
-                "remark-parse": "^9.0.0",
-                "unified": "^9.0.0",
-                "unist-util-visit": "^2.0.0",
-                "xtend": "^4.0.1"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            },
-            "peerDependencies": {
-                "@types/react": ">=16",
-                "react": ">=16"
-            }
-        },
-        "node_modules/@doist/reactist/node_modules/remark-parse": {
-            "version": "9.0.0",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "mdast-util-from-markdown": "^0.8.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/@doist/tsconfig": {
@@ -2176,6 +2114,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/@floating-ui/core": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.1.tgz",
+            "integrity": "sha512-grcqEmI8DTIolufpxhJagVeJmvloxBXE6xxSrVnSXz/Wz1uUIsC85ad+UNBqAoBOvzLxE42wvDj3YkmSGqWRxA==",
+            "dev": true
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.1.tgz",
+            "integrity": "sha512-dkPSy5JPiQEtljc3VpG9lauYctxfLlqj/8N9f+lmsR92gQaSVMAWuBbFBH2keY5DmdQn3p4Dv1dQd+e8osH+/g==",
+            "dev": true,
+            "dependencies": {
+                "@floating-ui/core": "^0.7.1"
             }
         },
         "node_modules/@gar/promisify": {
@@ -4215,6 +4168,7 @@
         },
         "node_modules/@popperjs/core": {
             "version": "2.11.2",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -4223,8 +4177,8 @@
         },
         "node_modules/@reach/dialog": {
             "version": "0.16.2",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@reach/portal": "0.16.2",
                 "@reach/utils": "0.16.0",
@@ -4240,8 +4194,8 @@
         },
         "node_modules/@reach/dialog/node_modules/react-remove-scroll": {
             "version": "2.4.3",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "react-remove-scroll-bar": "^2.1.0",
                 "react-style-singleton": "^2.1.0",
@@ -4264,8 +4218,8 @@
         },
         "node_modules/@reach/dialog/node_modules/react-remove-scroll-bar": {
             "version": "2.2.0",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "react-style-singleton": "^2.1.0",
                 "tslib": "^1.0.0"
@@ -4285,18 +4239,18 @@
         },
         "node_modules/@reach/dialog/node_modules/react-remove-scroll-bar/node_modules/tslib": {
             "version": "1.14.1",
-            "license": "0BSD",
-            "peer": true
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/@reach/dialog/node_modules/react-remove-scroll/node_modules/tslib": {
             "version": "1.14.1",
-            "license": "0BSD",
-            "peer": true
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/@reach/dialog/node_modules/react-style-singleton": {
             "version": "2.1.1",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "get-nonce": "^1.0.0",
                 "invariant": "^2.2.4",
@@ -4317,13 +4271,13 @@
         },
         "node_modules/@reach/dialog/node_modules/react-style-singleton/node_modules/tslib": {
             "version": "1.14.1",
-            "license": "0BSD",
-            "peer": true
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/@reach/dialog/node_modules/use-callback-ref": {
             "version": "1.2.5",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8.5.0"
             },
@@ -4339,8 +4293,8 @@
         },
         "node_modules/@reach/portal": {
             "version": "0.16.2",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@reach/utils": "0.16.0",
                 "tiny-warning": "^1.0.3",
@@ -4353,8 +4307,8 @@
         },
         "node_modules/@reach/utils": {
             "version": "0.16.0",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tiny-warning": "^1.0.3",
                 "tslib": "^2.3.0"
@@ -9745,6 +9699,7 @@
         },
         "node_modules/@types/jest": {
             "version": "27.4.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "jest-diff": "^27.0.0",
@@ -9753,6 +9708,7 @@
         },
         "node_modules/@types/jest/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9760,6 +9716,7 @@
         },
         "node_modules/@types/jest/node_modules/ansi-styles": {
             "version": "4.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -9773,6 +9730,7 @@
         },
         "node_modules/@types/jest/node_modules/chalk": {
             "version": "4.1.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
@@ -9787,6 +9745,7 @@
         },
         "node_modules/@types/jest/node_modules/diff-sequences": {
             "version": "27.5.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -9794,6 +9753,7 @@
         },
         "node_modules/@types/jest/node_modules/has-flag": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9801,6 +9761,7 @@
         },
         "node_modules/@types/jest/node_modules/jest-diff": {
             "version": "27.5.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.0.0",
@@ -9814,6 +9775,7 @@
         },
         "node_modules/@types/jest/node_modules/jest-get-type": {
             "version": "27.5.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -9821,6 +9783,7 @@
         },
         "node_modules/@types/jest/node_modules/pretty-format": {
             "version": "27.5.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1",
@@ -9833,6 +9796,7 @@
         },
         "node_modules/@types/jest/node_modules/pretty-format/node_modules/ansi-styles": {
             "version": "5.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -9843,10 +9807,12 @@
         },
         "node_modules/@types/jest/node_modules/react-is": {
             "version": "17.0.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/jest/node_modules/supports-color": {
             "version": "7.2.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -9873,6 +9839,7 @@
         },
         "node_modules/@types/mdast": {
             "version": "3.0.10",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
@@ -9941,6 +9908,7 @@
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/q": {
@@ -9955,6 +9923,7 @@
         },
         "node_modules/@types/react": {
             "version": "16.14.5",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
@@ -9989,6 +9958,7 @@
         },
         "node_modules/@types/react/node_modules/csstype": {
             "version": "3.0.7",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/resolve": {
@@ -10001,6 +9971,7 @@
         },
         "node_modules/@types/scheduler": {
             "version": "0.16.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/set-cookie-parser": {
@@ -10028,14 +9999,6 @@
             "license": "MIT",
             "dependencies": {
                 "pretty-format": "^24.3.0"
-            }
-        },
-        "node_modules/@types/testing-library__jest-dom": {
-            "version": "5.14.2",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/jest": "*"
             }
         },
         "node_modules/@types/testing-library__react": {
@@ -10173,6 +10136,7 @@
         },
         "node_modules/@types/unist": {
             "version": "2.0.6",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/webpack": {
@@ -10634,8 +10598,8 @@
         },
         "node_modules/@yarnpkg/lockfile": {
             "version": "1.1.0",
-            "license": "BSD-2-Clause",
-            "peer": true
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/abab": {
             "version": "2.0.5",
@@ -10853,6 +10817,7 @@
         },
         "node_modules/ansi-styles": {
             "version": "3.2.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^1.9.0"
@@ -10863,6 +10828,7 @@
         },
         "node_modules/ansi-styles/node_modules/color-convert": {
             "version": "1.9.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "1.1.3"
@@ -10870,6 +10836,7 @@
         },
         "node_modules/ansi-styles/node_modules/color-name": {
             "version": "1.1.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/ansi-to-html": {
@@ -11939,6 +11906,7 @@
         },
         "node_modules/bail": {
             "version": "1.0.5",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -11947,6 +11915,7 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/base": {
@@ -12191,11 +12160,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/body-scroll-lock": {
-            "version": "3.1.5",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "dev": true,
@@ -12289,6 +12253,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -12297,6 +12262,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.0.1"
@@ -12779,6 +12745,7 @@
         },
         "node_modules/chalk": {
             "version": "2.4.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^3.2.1",
@@ -12799,6 +12766,7 @@
         },
         "node_modules/character-entities": {
             "version": "1.2.4",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -12807,6 +12775,7 @@
         },
         "node_modules/character-entities-legacy": {
             "version": "1.1.4",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -12815,6 +12784,7 @@
         },
         "node_modules/character-reference-invalid": {
             "version": "1.1.4",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -13062,6 +13032,7 @@
         },
         "node_modules/ci-info": {
             "version": "2.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/cipher-base": {
@@ -13399,6 +13370,7 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -13409,6 +13381,7 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/color-string": {
@@ -13560,6 +13533,7 @@
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/concat-stream": {
@@ -14732,6 +14706,7 @@
         },
         "node_modules/debug": {
             "version": "4.3.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "2.1.2"
@@ -14898,8 +14873,8 @@
         },
         "node_modules/detect-node-es": {
             "version": "1.1.0",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/detect-port": {
             "version": "1.3.0",
@@ -15051,6 +15026,7 @@
         },
         "node_modules/domhandler": {
             "version": "4.3.0",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "domelementtype": "^2.2.0"
@@ -15064,6 +15040,7 @@
         },
         "node_modules/domhandler/node_modules/domelementtype": {
             "version": "2.2.0",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -15446,6 +15423,7 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "1.0.5",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
@@ -16755,6 +16733,7 @@
         },
         "node_modules/extend": {
             "version": "3.0.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/extend-shallow": {
@@ -17036,6 +17015,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -17201,8 +17181,8 @@
         },
         "node_modules/find-yarn-workspace-root": {
             "version": "2.0.0",
+            "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "micromatch": "^4.0.2"
             }
@@ -17235,8 +17215,8 @@
         },
         "node_modules/focus-lock": {
             "version": "0.10.1",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.0.3"
             },
@@ -17542,6 +17522,7 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/fsevents": {
@@ -17696,8 +17677,8 @@
         },
         "node_modules/get-nonce": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -17761,6 +17742,7 @@
         },
         "node_modules/glob": {
             "version": "7.1.6",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -17863,6 +17845,7 @@
         },
         "node_modules/graceful-fs": {
             "version": "4.2.9",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/graphql": {
@@ -17932,6 +17915,7 @@
         },
         "node_modules/has-flag": {
             "version": "3.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -18352,8 +18336,8 @@
         },
         "node_modules/html-to-react": {
             "version": "1.4.7",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "domhandler": "^4.0",
                 "htmlparser2": "^7.0",
@@ -18366,8 +18350,8 @@
         },
         "node_modules/html-to-react/node_modules/dom-serializer": {
             "version": "1.3.2",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.2.0",
@@ -18379,27 +18363,27 @@
         },
         "node_modules/html-to-react/node_modules/dom-serializer/node_modules/entities": {
             "version": "2.2.0",
+            "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/html-to-react/node_modules/domelementtype": {
             "version": "2.2.0",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/fb55"
                 }
             ],
-            "license": "BSD-2-Clause",
-            "peer": true
+            "license": "BSD-2-Clause"
         },
         "node_modules/html-to-react/node_modules/domutils": {
             "version": "2.8.0",
+            "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
@@ -18411,8 +18395,8 @@
         },
         "node_modules/html-to-react/node_modules/entities": {
             "version": "3.0.1",
+            "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=0.12"
             },
@@ -18422,6 +18406,7 @@
         },
         "node_modules/html-to-react/node_modules/htmlparser2": {
             "version": "7.2.0",
+            "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -18430,7 +18415,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.2.2",
@@ -18440,8 +18424,8 @@
         },
         "node_modules/html-to-react/node_modules/ramda": {
             "version": "0.27.1",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/html-void-elements": {
             "version": "1.0.5",
@@ -18946,6 +18930,7 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
@@ -18954,6 +18939,7 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/ini": {
@@ -19092,6 +19078,7 @@
         },
         "node_modules/invariant": {
             "version": "2.2.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.0.0"
@@ -19134,6 +19121,7 @@
         },
         "node_modules/is-alphabetical": {
             "version": "1.0.4",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -19142,6 +19130,7 @@
         },
         "node_modules/is-alphanumerical": {
             "version": "1.0.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-alphabetical": "^1.0.0",
@@ -19208,6 +19197,7 @@
         },
         "node_modules/is-buffer": {
             "version": "2.0.5",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -19240,6 +19230,7 @@
         },
         "node_modules/is-ci": {
             "version": "2.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ci-info": "^2.0.0"
@@ -19296,6 +19287,7 @@
         },
         "node_modules/is-decimal": {
             "version": "1.0.4",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -19325,6 +19317,7 @@
         },
         "node_modules/is-docker": {
             "version": "2.2.0",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "is-docker": "cli.js"
@@ -19398,6 +19391,7 @@
         },
         "node_modules/is-hexadecimal": {
             "version": "1.0.4",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -19446,6 +19440,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
@@ -19480,6 +19475,7 @@
         },
         "node_modules/is-plain-obj": {
             "version": "2.1.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -19657,6 +19653,7 @@
         },
         "node_modules/is-wsl": {
             "version": "2.2.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-docker": "^2.0.0"
@@ -19673,6 +19670,7 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/isobject": {
@@ -23190,6 +23188,7 @@
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/js-yaml": {
@@ -23361,8 +23360,8 @@
         },
         "node_modules/klaw-sync": {
             "version": "6.0.0",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.11"
             }
@@ -23524,6 +23523,7 @@
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.debounce": {
@@ -23649,6 +23649,7 @@
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -23791,16 +23792,16 @@
         },
         "node_modules/mdast-add-list-metadata": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "unist-util-visit-parents": "1.1.2"
             }
         },
         "node_modules/mdast-add-list-metadata/node_modules/unist-util-visit-parents": {
             "version": "1.1.2",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/mdast-squeeze-paragraphs": {
             "version": "4.0.0",
@@ -23830,8 +23831,8 @@
         },
         "node_modules/mdast-util-from-markdown": {
             "version": "0.8.5",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/mdast": "^3.0.0",
                 "mdast-util-to-string": "^2.0.0",
@@ -23866,8 +23867,8 @@
         },
         "node_modules/mdast-util-to-string": {
             "version": "2.0.0",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
@@ -23968,6 +23969,7 @@
         },
         "node_modules/micromark": {
             "version": "2.11.4",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -23979,7 +23981,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "debug": "^4.0.0",
                 "parse-entities": "^2.0.0"
@@ -23987,6 +23988,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.1",
@@ -24079,6 +24081,7 @@
         },
         "node_modules/minimatch": {
             "version": "3.0.4",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -24090,7 +24093,8 @@
         "node_modules/minimist": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
         },
         "node_modules/minipass": {
             "version": "3.1.6",
@@ -24222,6 +24226,7 @@
         },
         "node_modules/ms": {
             "version": "2.1.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/msw": {
@@ -24416,6 +24421,7 @@
         },
         "node_modules/nice-try": {
             "version": "1.0.5",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/no-case": {
@@ -24783,6 +24789,7 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -25043,6 +25050,7 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -25064,6 +25072,7 @@
         },
         "node_modules/open": {
             "version": "7.4.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-docker": "^2.0.0",
@@ -25203,6 +25212,7 @@
         },
         "node_modules/os-tmpdir": {
             "version": "1.0.2",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -25409,6 +25419,7 @@
         },
         "node_modules/parse-entities": {
             "version": "2.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "character-entities": "^1.0.0",
@@ -25474,8 +25485,8 @@
         },
         "node_modules/patch-package": {
             "version": "6.4.7",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@yarnpkg/lockfile": "^1.1.0",
                 "chalk": "^2.4.2",
@@ -25500,8 +25511,8 @@
         },
         "node_modules/patch-package/node_modules/cross-spawn": {
             "version": "6.0.5",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -25515,8 +25526,8 @@
         },
         "node_modules/patch-package/node_modules/fs-extra": {
             "version": "7.0.1",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -25528,24 +25539,24 @@
         },
         "node_modules/patch-package/node_modules/jsonfile": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/patch-package/node_modules/path-key": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/patch-package/node_modules/rimraf": {
             "version": "2.7.1",
+            "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -25555,16 +25566,16 @@
         },
         "node_modules/patch-package/node_modules/semver": {
             "version": "5.7.1",
+            "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver"
             }
         },
         "node_modules/patch-package/node_modules/shebang-command": {
             "version": "1.2.0",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "shebang-regex": "^1.0.0"
             },
@@ -25574,32 +25585,32 @@
         },
         "node_modules/patch-package/node_modules/shebang-regex": {
             "version": "1.0.0",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/patch-package/node_modules/slash": {
             "version": "2.0.0",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/patch-package/node_modules/universalify": {
             "version": "0.1.2",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
         },
         "node_modules/patch-package/node_modules/which": {
             "version": "1.3.1",
+            "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -25627,6 +25638,7 @@
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -25681,6 +25693,7 @@
         },
         "node_modules/picomatch": {
             "version": "2.3.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -27543,6 +27556,7 @@
         },
         "node_modules/prop-types": {
             "version": "15.7.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.4.0",
@@ -27818,6 +27832,7 @@
         },
         "node_modules/react": {
             "version": "16.14.0",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -27831,8 +27846,8 @@
         },
         "node_modules/react-clientside-effect": {
             "version": "1.2.5",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.13"
             },
@@ -27925,6 +27940,7 @@
         },
         "node_modules/react-dom": {
             "version": "16.14.0",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -27989,8 +28005,8 @@
         },
         "node_modules/react-focus-lock": {
             "version": "2.7.1",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.0.0",
                 "focus-lock": "^0.10.1",
@@ -28005,8 +28021,8 @@
         },
         "node_modules/react-focus-lock/node_modules/use-callback-ref": {
             "version": "1.2.5",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8.5.0"
             },
@@ -28052,12 +28068,13 @@
         },
         "node_modules/react-is": {
             "version": "16.13.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/react-keyed-flatten-children": {
             "version": "1.3.0",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "react-is": "^16.8.6"
             },
@@ -28379,58 +28396,6 @@
                 "node": ">=8.10.0"
             }
         },
-        "node_modules/reakit": {
-            "version": "1.3.0",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@popperjs/core": "^2.4.4",
-                "body-scroll-lock": "^3.1.5",
-                "reakit-system": "^0.15.0",
-                "reakit-utils": "^0.15.0",
-                "reakit-warning": "^0.6.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/reakit"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0",
-                "react-dom": "^16.8.0"
-            }
-        },
-        "node_modules/reakit-system": {
-            "version": "0.15.2",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "reakit-utils": "^0.15.2"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            }
-        },
-        "node_modules/reakit-utils": {
-            "version": "0.15.2",
-            "license": "MIT",
-            "peer": true,
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            }
-        },
-        "node_modules/reakit-warning": {
-            "version": "0.6.2",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "reakit-utils": "^0.15.2"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0"
-            }
-        },
         "node_modules/redent": {
             "version": "3.0.0",
             "dev": true,
@@ -28486,6 +28451,7 @@
         },
         "node_modules/regenerator-runtime": {
             "version": "0.13.7",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/regenerator-transform": {
@@ -30202,6 +30168,7 @@
         },
         "node_modules/scheduler": {
             "version": "0.19.1",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -31331,6 +31298,7 @@
         },
         "node_modules/supports-color": {
             "version": "5.5.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^3.0.0"
@@ -31853,11 +31821,12 @@
         },
         "node_modules/tiny-warning": {
             "version": "1.0.3",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tmp": {
             "version": "0.0.33",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "os-tmpdir": "~1.0.2"
@@ -31927,6 +31896,7 @@
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -32000,6 +31970,7 @@
         },
         "node_modules/trough": {
             "version": "1.0.5",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -32475,6 +32446,7 @@
         },
         "node_modules/unified": {
             "version": "9.2.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bail": "^1.0.0",
@@ -32559,6 +32531,7 @@
         },
         "node_modules/unist-util-is": {
             "version": "4.1.0",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -32603,6 +32576,7 @@
         },
         "node_modules/unist-util-stringify-position": {
             "version": "2.0.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^2.0.2"
@@ -32614,6 +32588,7 @@
         },
         "node_modules/unist-util-visit": {
             "version": "2.0.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^2.0.0",
@@ -32627,6 +32602,7 @@
         },
         "node_modules/unist-util-visit-parents": {
             "version": "3.1.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^2.0.0",
@@ -32856,8 +32832,8 @@
         },
         "node_modules/use-sidecar": {
             "version": "1.0.5",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "detect-node-es": "^1.1.0",
                 "tslib": "^1.9.3"
@@ -32871,8 +32847,8 @@
         },
         "node_modules/use-sidecar/node_modules/tslib": {
             "version": "1.14.1",
-            "license": "0BSD",
-            "peer": true
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/util": {
             "version": "0.11.1",
@@ -32984,6 +32960,7 @@
         },
         "node_modules/vfile": {
             "version": "4.2.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^2.0.0",
@@ -33008,6 +32985,7 @@
         },
         "node_modules/vfile-message": {
             "version": "2.0.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^2.0.0",
@@ -34072,6 +34050,7 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/write-file-atomic": {
@@ -34117,6 +34096,7 @@
         },
         "node_modules/xtend": {
             "version": "4.0.2",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4"
@@ -34342,6 +34322,7 @@
                 "dayjs": "^1.9.1"
             },
             "devDependencies": {
+                "@doist/reactist": "^12.0.1",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -34401,6 +34382,89 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
+            }
+        },
+        "packages/ui-extensions-react/node_modules/@doist/reactist": {
+            "version": "12.0.1",
+            "resolved": "https://npm.pkg.github.com/download/@doist/reactist/12.0.1/fa1cea82f1240b5c4f5e3a8e5071855cb1d629a6cfd3e08e5bc16661f1aba5d8",
+            "integrity": "sha512-iFC7AcclICkvn6GYz3VbBI4K27mj9Lt23LXaG8QsuNuQ8o/whOhkUuH499hj57Fk/ifrAzpf6XXg757+6WhwOA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "@reach/dialog": "^0.16.0",
+                "ariakit": "^2.0.0-next.27",
+                "ariakit-utils": "^0.17.0-next.18",
+                "dayjs": "^1.8.10",
+                "patch-package": "^6.4.6",
+                "react-focus-lock": "^2.5.2",
+                "react-keyed-flatten-children": "^1.3.0",
+                "react-markdown": "^5.0.3"
+            },
+            "peerDependencies": {
+                "classnames": "^2.2.5",
+                "prop-types": "^15.6.2",
+                "react": "^17.0.0 || ^18.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0"
+            }
+        },
+        "packages/ui-extensions-react/node_modules/@doist/reactist/node_modules/ariakit": {
+            "version": "2.0.0-next.28",
+            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.28.tgz",
+            "integrity": "sha512-2p21YRxWKjxeGfj4a+Gq3nN68n+gkD0CpsE72UgNvdzyvs8lyZyWIOwovHYR0hcS6RZY4hTOq68ln+INGHF35g==",
+            "dev": true,
+            "dependencies": {
+                "@floating-ui/dom": "0.5.1",
+                "ariakit-utils": "0.17.0-next.19"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ariakit"
+            },
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0"
+            }
+        },
+        "packages/ui-extensions-react/node_modules/@doist/reactist/node_modules/ariakit-utils": {
+            "version": "0.17.0-next.19",
+            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.19.tgz",
+            "integrity": "sha512-rEC2npqK0WQtnNPEAicfcwxd/sQ9EdaRqf6p10ExhL5EUy/xoJpTGBAb67xSSHBu1hrqDFtfmF3FrHd6JOj2EA==",
+            "dev": true,
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0"
+            }
+        },
+        "packages/ui-extensions-react/node_modules/@doist/reactist/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "dev": true
+        },
+        "packages/ui-extensions-react/node_modules/@doist/reactist/node_modules/react-markdown": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz",
+            "integrity": "sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.3",
+                "@types/unist": "^2.0.3",
+                "html-to-react": "^1.3.4",
+                "mdast-add-list-metadata": "1.0.1",
+                "prop-types": "^15.7.2",
+                "react-is": "^16.8.6",
+                "remark-parse": "^9.0.0",
+                "unified": "^9.0.0",
+                "unist-util-visit": "^2.0.0",
+                "xtend": "^4.0.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            },
+            "peerDependencies": {
+                "@types/react": ">=16",
+                "react": ">=16"
             }
         },
         "packages/ui-extensions-react/node_modules/@eslint/eslintrc": {
@@ -35162,6 +35226,19 @@
             },
             "peerDependencies": {
                 "react": "17.0.2"
+            }
+        },
+        "packages/ui-extensions-react/node_modules/remark-parse": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+            "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+            "dev": true,
+            "dependencies": {
+                "mdast-util-from-markdown": "^0.8.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "packages/ui-extensions-react/node_modules/resolve": {
@@ -36292,6 +36369,7 @@
         },
         "@babel/runtime": {
             "version": "7.16.7",
+            "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             }
@@ -36375,45 +36453,6 @@
             "dev": true,
             "requires": {}
         },
-        "@doist/reactist": {
-            "version": "11.0.0",
-            "peer": true,
-            "requires": {
-                "@reach/dialog": "^0.16.0",
-                "@types/testing-library__jest-dom": "^5.14.1",
-                "dayjs": "^1.8.10",
-                "patch-package": "^6.4.6",
-                "react-focus-lock": "^2.5.2",
-                "react-keyed-flatten-children": "^1.3.0",
-                "react-markdown": "^5.0.3",
-                "reakit": "1.3.0"
-            },
-            "dependencies": {
-                "react-markdown": {
-                    "version": "5.0.3",
-                    "peer": true,
-                    "requires": {
-                        "@types/mdast": "^3.0.3",
-                        "@types/unist": "^2.0.3",
-                        "html-to-react": "^1.3.4",
-                        "mdast-add-list-metadata": "1.0.1",
-                        "prop-types": "^15.7.2",
-                        "react-is": "^16.8.6",
-                        "remark-parse": "^9.0.0",
-                        "unified": "^9.0.0",
-                        "unist-util-visit": "^2.0.0",
-                        "xtend": "^4.0.1"
-                    }
-                },
-                "remark-parse": {
-                    "version": "9.0.0",
-                    "peer": true,
-                    "requires": {
-                        "mdast-util-from-markdown": "^0.8.0"
-                    }
-                }
-            }
-        },
         "@doist/tsconfig": {
             "version": "1.0.0",
             "dev": true
@@ -36427,6 +36466,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
+                "@doist/reactist": "*",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -36438,10 +36478,10 @@
                 "dayjs": "^1.9.1",
                 "eslint-config-react-app": "^7.0.0",
                 "msw": "^0.36.8",
-                "react": "^17.0.0",
-                "react-dom": "^17.0.0",
-                "react-is": "^17.0.0",
-                "react-test-renderer": "^17.0.0"
+                "react": "^17.0.2",
+                "react-dom": "^17.0.2",
+                "react-is": "^17.0.2",
+                "react-test-renderer": "^17.0.2"
             },
             "dependencies": {
                 "@babel/eslint-parser": {
@@ -36464,6 +36504,65 @@
                         "estraverse": {
                             "version": "4.3.0",
                             "dev": true
+                        }
+                    }
+                },
+                "@doist/reactist": {
+                    "version": "12.0.1",
+                    "resolved": "https://npm.pkg.github.com/download/@doist/reactist/12.0.1/fa1cea82f1240b5c4f5e3a8e5071855cb1d629a6cfd3e08e5bc16661f1aba5d8",
+                    "integrity": "sha512-iFC7AcclICkvn6GYz3VbBI4K27mj9Lt23LXaG8QsuNuQ8o/whOhkUuH499hj57Fk/ifrAzpf6XXg757+6WhwOA==",
+                    "dev": true,
+                    "requires": {
+                        "@reach/dialog": "^0.16.0",
+                        "ariakit": "^2.0.0-next.27",
+                        "ariakit-utils": "^0.17.0-next.18",
+                        "dayjs": "^1.8.10",
+                        "patch-package": "^6.4.6",
+                        "react-focus-lock": "^2.5.2",
+                        "react-keyed-flatten-children": "^1.3.0",
+                        "react-markdown": "^5.0.3"
+                    },
+                    "dependencies": {
+                        "ariakit": {
+                            "version": "2.0.0-next.28",
+                            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.28.tgz",
+                            "integrity": "sha512-2p21YRxWKjxeGfj4a+Gq3nN68n+gkD0CpsE72UgNvdzyvs8lyZyWIOwovHYR0hcS6RZY4hTOq68ln+INGHF35g==",
+                            "dev": true,
+                            "requires": {
+                                "@floating-ui/dom": "0.5.1",
+                                "ariakit-utils": "0.17.0-next.19"
+                            }
+                        },
+                        "ariakit-utils": {
+                            "version": "0.17.0-next.19",
+                            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.19.tgz",
+                            "integrity": "sha512-rEC2npqK0WQtnNPEAicfcwxd/sQ9EdaRqf6p10ExhL5EUy/xoJpTGBAb67xSSHBu1hrqDFtfmF3FrHd6JOj2EA==",
+                            "dev": true,
+                            "requires": {}
+                        },
+                        "react-is": {
+                            "version": "16.13.1",
+                            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+                            "dev": true
+                        },
+                        "react-markdown": {
+                            "version": "5.0.3",
+                            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz",
+                            "integrity": "sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==",
+                            "dev": true,
+                            "requires": {
+                                "@types/mdast": "^3.0.3",
+                                "@types/unist": "^2.0.3",
+                                "html-to-react": "^1.3.4",
+                                "mdast-add-list-metadata": "1.0.1",
+                                "prop-types": "^15.7.2",
+                                "react-is": "^16.8.6",
+                                "remark-parse": "^9.0.0",
+                                "unified": "^9.0.0",
+                                "unist-util-visit": "^2.0.0",
+                                "xtend": "^4.0.1"
+                            }
                         }
                     }
                 },
@@ -36927,6 +37026,15 @@
                         "scheduler": "^0.20.2"
                     }
                 },
+                "remark-parse": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+                    "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+                    "dev": true,
+                    "requires": {
+                        "mdast-util-from-markdown": "^0.8.0"
+                    }
+                },
                 "resolve": {
                     "version": "2.0.0-next.3",
                     "dev": true,
@@ -37092,6 +37200,21 @@
                     "version": "4.0.6",
                     "dev": true
                 }
+            }
+        },
+        "@floating-ui/core": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.1.tgz",
+            "integrity": "sha512-grcqEmI8DTIolufpxhJagVeJmvloxBXE6xxSrVnSXz/Wz1uUIsC85ad+UNBqAoBOvzLxE42wvDj3YkmSGqWRxA==",
+            "dev": true
+        },
+        "@floating-ui/dom": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.1.tgz",
+            "integrity": "sha512-dkPSy5JPiQEtljc3VpG9lauYctxfLlqj/8N9f+lmsR92gQaSVMAWuBbFBH2keY5DmdQn3p4Dv1dQd+e8osH+/g==",
+            "dev": true,
+            "requires": {
+                "@floating-ui/core": "^0.7.1"
             }
         },
         "@gar/promisify": {
@@ -38512,11 +38635,12 @@
             "dev": true
         },
         "@popperjs/core": {
-            "version": "2.11.2"
+            "version": "2.11.2",
+            "dev": true
         },
         "@reach/dialog": {
             "version": "0.16.2",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "@reach/portal": "0.16.2",
                 "@reach/utils": "0.16.0",
@@ -38528,7 +38652,7 @@
             "dependencies": {
                 "react-remove-scroll": {
                     "version": "2.4.3",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "react-remove-scroll-bar": "^2.1.0",
                         "react-style-singleton": "^2.1.0",
@@ -38539,13 +38663,13 @@
                     "dependencies": {
                         "tslib": {
                             "version": "1.14.1",
-                            "peer": true
+                            "dev": true
                         }
                     }
                 },
                 "react-remove-scroll-bar": {
                     "version": "2.2.0",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "react-style-singleton": "^2.1.0",
                         "tslib": "^1.0.0"
@@ -38553,13 +38677,13 @@
                     "dependencies": {
                         "tslib": {
                             "version": "1.14.1",
-                            "peer": true
+                            "dev": true
                         }
                     }
                 },
                 "react-style-singleton": {
                     "version": "2.1.1",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "get-nonce": "^1.0.0",
                         "invariant": "^2.2.4",
@@ -38568,20 +38692,20 @@
                     "dependencies": {
                         "tslib": {
                             "version": "1.14.1",
-                            "peer": true
+                            "dev": true
                         }
                     }
                 },
                 "use-callback-ref": {
                     "version": "1.2.5",
-                    "peer": true,
+                    "dev": true,
                     "requires": {}
                 }
             }
         },
         "@reach/portal": {
             "version": "0.16.2",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "@reach/utils": "0.16.0",
                 "tiny-warning": "^1.0.3",
@@ -38590,7 +38714,7 @@
         },
         "@reach/utils": {
             "version": "0.16.0",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "tiny-warning": "^1.0.3",
                 "tslib": "^2.3.0"
@@ -42361,35 +42485,42 @@
         },
         "@types/jest": {
             "version": "27.4.0",
+            "dev": true,
             "requires": {
                 "jest-diff": "^27.0.0",
                 "pretty-format": "^27.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "5.0.1"
+                    "version": "5.0.1",
+                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "4.3.0",
+                    "dev": true,
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
                     "version": "4.1.2",
+                    "dev": true,
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
                     }
                 },
                 "diff-sequences": {
-                    "version": "27.5.1"
+                    "version": "27.5.1",
+                    "dev": true
                 },
                 "has-flag": {
-                    "version": "4.0.0"
+                    "version": "4.0.0",
+                    "dev": true
                 },
                 "jest-diff": {
                     "version": "27.5.1",
+                    "dev": true,
                     "requires": {
                         "chalk": "^4.0.0",
                         "diff-sequences": "^27.5.1",
@@ -42398,10 +42529,12 @@
                     }
                 },
                 "jest-get-type": {
-                    "version": "27.5.1"
+                    "version": "27.5.1",
+                    "dev": true
                 },
                 "pretty-format": {
                     "version": "27.5.1",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^5.0.1",
                         "ansi-styles": "^5.0.0",
@@ -42409,15 +42542,18 @@
                     },
                     "dependencies": {
                         "ansi-styles": {
-                            "version": "5.2.0"
+                            "version": "5.2.0",
+                            "dev": true
                         }
                     }
                 },
                 "react-is": {
-                    "version": "17.0.2"
+                    "version": "17.0.2",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "7.2.0",
+                    "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -42440,6 +42576,7 @@
         },
         "@types/mdast": {
             "version": "3.0.10",
+            "dev": true,
             "requires": {
                 "@types/unist": "*"
             }
@@ -42503,7 +42640,8 @@
             "dev": true
         },
         "@types/prop-types": {
-            "version": "15.7.3"
+            "version": "15.7.3",
+            "dev": true
         },
         "@types/q": {
             "version": "1.5.4",
@@ -42515,6 +42653,7 @@
         },
         "@types/react": {
             "version": "16.14.5",
+            "dev": true,
             "requires": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -42522,7 +42661,8 @@
             },
             "dependencies": {
                 "csstype": {
-                    "version": "3.0.7"
+                    "version": "3.0.7",
+                    "dev": true
                 }
             }
         },
@@ -42557,7 +42697,8 @@
             }
         },
         "@types/scheduler": {
-            "version": "0.16.1"
+            "version": "0.16.1",
+            "dev": true
         },
         "@types/set-cookie-parser": {
             "version": "2.4.2",
@@ -42581,13 +42722,6 @@
             "dev": true,
             "requires": {
                 "pretty-format": "^24.3.0"
-            }
-        },
-        "@types/testing-library__jest-dom": {
-            "version": "5.14.2",
-            "peer": true,
-            "requires": {
-                "@types/jest": "*"
             }
         },
         "@types/testing-library__react": {
@@ -42689,7 +42823,8 @@
             }
         },
         "@types/unist": {
-            "version": "2.0.6"
+            "version": "2.0.6",
+            "dev": true
         },
         "@types/webpack": {
             "version": "4.41.32",
@@ -43012,7 +43147,7 @@
         },
         "@yarnpkg/lockfile": {
             "version": "1.1.0",
-            "peer": true
+            "dev": true
         },
         "abab": {
             "version": "2.0.5",
@@ -43161,18 +43296,21 @@
         },
         "ansi-styles": {
             "version": "3.2.1",
+            "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
             },
             "dependencies": {
                 "color-convert": {
                     "version": "1.9.3",
+                    "dev": true,
                     "requires": {
                         "color-name": "1.1.3"
                     }
                 },
                 "color-name": {
-                    "version": "1.1.3"
+                    "version": "1.1.3",
+                    "dev": true
                 }
             }
         },
@@ -43931,10 +44069,12 @@
             }
         },
         "bail": {
-            "version": "1.0.5"
+            "version": "1.0.5",
+            "dev": true
         },
         "balanced-match": {
-            "version": "1.0.2"
+            "version": "1.0.2",
+            "dev": true
         },
         "base": {
             "version": "0.11.2",
@@ -44107,10 +44247,6 @@
                 }
             }
         },
-        "body-scroll-lock": {
-            "version": "3.1.5",
-            "peer": true
-        },
         "boolbase": {
             "version": "1.0.0",
             "dev": true
@@ -44175,6 +44311,7 @@
         },
         "brace-expansion": {
             "version": "1.1.11",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -44182,6 +44319,7 @@
         },
         "braces": {
             "version": "3.0.2",
+            "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -44534,6 +44672,7 @@
         },
         "chalk": {
             "version": "2.4.2",
+            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -44545,13 +44684,16 @@
             "dev": true
         },
         "character-entities": {
-            "version": "1.2.4"
+            "version": "1.2.4",
+            "dev": true
         },
         "character-entities-legacy": {
-            "version": "1.1.4"
+            "version": "1.1.4",
+            "dev": true
         },
         "character-reference-invalid": {
-            "version": "1.1.4"
+            "version": "1.1.4",
+            "dev": true
         },
         "chardet": {
             "version": "0.7.0",
@@ -44718,7 +44860,8 @@
             }
         },
         "ci-info": {
-            "version": "2.0.0"
+            "version": "2.0.0",
+            "dev": true
         },
         "cipher-base": {
             "version": "1.0.4",
@@ -44972,12 +45115,14 @@
         },
         "color-convert": {
             "version": "2.0.1",
+            "dev": true,
             "requires": {
                 "color-name": "~1.1.4"
             }
         },
         "color-name": {
-            "version": "1.1.4"
+            "version": "1.1.4",
+            "dev": true
         },
         "color-string": {
             "version": "1.5.5",
@@ -45087,7 +45232,8 @@
             "dev": true
         },
         "concat-map": {
-            "version": "0.0.1"
+            "version": "0.0.1",
+            "dev": true
         },
         "concat-stream": {
             "version": "1.6.2",
@@ -45954,6 +46100,7 @@
         },
         "debug": {
             "version": "4.3.3",
+            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -46065,7 +46212,7 @@
         },
         "detect-node-es": {
             "version": "1.1.0",
-            "peer": true
+            "dev": true
         },
         "detect-port": {
             "version": "1.3.0",
@@ -46181,12 +46328,14 @@
         },
         "domhandler": {
             "version": "4.3.0",
+            "dev": true,
             "requires": {
                 "domelementtype": "^2.2.0"
             },
             "dependencies": {
                 "domelementtype": {
-                    "version": "2.2.0"
+                    "version": "2.2.0",
+                    "dev": true
                 }
             }
         },
@@ -46486,7 +46635,8 @@
             "dev": true
         },
         "escape-string-regexp": {
-            "version": "1.0.5"
+            "version": "1.0.5",
+            "dev": true
         },
         "escodegen": {
             "version": "2.0.0",
@@ -47377,7 +47527,8 @@
             }
         },
         "extend": {
-            "version": "3.0.2"
+            "version": "3.0.2",
+            "dev": true
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -47592,6 +47743,7 @@
         },
         "fill-range": {
             "version": "7.0.1",
+            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -47704,7 +47856,7 @@
         },
         "find-yarn-workspace-root": {
             "version": "2.0.0",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "micromatch": "^4.0.2"
             }
@@ -47731,7 +47883,7 @@
         },
         "focus-lock": {
             "version": "0.10.1",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "tslib": "^2.0.3"
             }
@@ -47970,7 +48122,8 @@
             }
         },
         "fs.realpath": {
-            "version": "1.0.0"
+            "version": "1.0.0",
+            "dev": true
         },
         "fsevents": {
             "version": "1.2.13",
@@ -48080,7 +48233,7 @@
         },
         "get-nonce": {
             "version": "1.0.1",
-            "peer": true
+            "dev": true
         },
         "get-package-type": {
             "version": "0.1.0",
@@ -48119,6 +48272,7 @@
         },
         "glob": {
             "version": "7.1.6",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -48185,7 +48339,8 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.9"
+            "version": "4.2.9",
+            "dev": true
         },
         "graphql": {
             "version": "15.8.0",
@@ -48232,7 +48387,8 @@
             "dev": true
         },
         "has-flag": {
-            "version": "3.0.0"
+            "version": "3.0.0",
+            "dev": true
         },
         "has-glob": {
             "version": "1.0.0",
@@ -48537,7 +48693,7 @@
         },
         "html-to-react": {
             "version": "1.4.7",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "domhandler": "^4.0",
                 "htmlparser2": "^7.0",
@@ -48547,7 +48703,7 @@
             "dependencies": {
                 "dom-serializer": {
                     "version": "1.3.2",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "domelementtype": "^2.0.1",
                         "domhandler": "^4.2.0",
@@ -48556,17 +48712,17 @@
                     "dependencies": {
                         "entities": {
                             "version": "2.2.0",
-                            "peer": true
+                            "dev": true
                         }
                     }
                 },
                 "domelementtype": {
                     "version": "2.2.0",
-                    "peer": true
+                    "dev": true
                 },
                 "domutils": {
                     "version": "2.8.0",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "dom-serializer": "^1.0.1",
                         "domelementtype": "^2.2.0",
@@ -48575,11 +48731,11 @@
                 },
                 "entities": {
                     "version": "3.0.1",
-                    "peer": true
+                    "dev": true
                 },
                 "htmlparser2": {
                     "version": "7.2.0",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "domelementtype": "^2.0.1",
                         "domhandler": "^4.2.2",
@@ -48589,7 +48745,7 @@
                 },
                 "ramda": {
                     "version": "0.27.1",
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -48924,13 +49080,15 @@
         },
         "inflight": {
             "version": "1.0.6",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
             }
         },
         "inherits": {
-            "version": "2.0.4"
+            "version": "2.0.4",
+            "dev": true
         },
         "ini": {
             "version": "2.0.0",
@@ -49032,6 +49190,7 @@
         },
         "invariant": {
             "version": "2.2.4",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.0.0"
             }
@@ -49062,10 +49221,12 @@
             }
         },
         "is-alphabetical": {
-            "version": "1.0.4"
+            "version": "1.0.4",
+            "dev": true
         },
         "is-alphanumerical": {
             "version": "1.0.4",
+            "dev": true,
             "requires": {
                 "is-alphabetical": "^1.0.0",
                 "is-decimal": "^1.0.0"
@@ -49104,7 +49265,8 @@
             }
         },
         "is-buffer": {
-            "version": "2.0.5"
+            "version": "2.0.5",
+            "dev": true
         },
         "is-callable": {
             "version": "1.2.4",
@@ -49112,6 +49274,7 @@
         },
         "is-ci": {
             "version": "2.0.0",
+            "dev": true,
             "requires": {
                 "ci-info": "^2.0.0"
             }
@@ -49147,7 +49310,8 @@
             "dev": true
         },
         "is-decimal": {
-            "version": "1.0.4"
+            "version": "1.0.4",
+            "dev": true
         },
         "is-descriptor": {
             "version": "1.0.2",
@@ -49163,7 +49327,8 @@
             "dev": true
         },
         "is-docker": {
-            "version": "2.2.0"
+            "version": "2.2.0",
+            "dev": true
         },
         "is-dom": {
             "version": "1.1.0",
@@ -49204,7 +49369,8 @@
             }
         },
         "is-hexadecimal": {
-            "version": "1.0.4"
+            "version": "1.0.4",
+            "dev": true
         },
         "is-interactive": {
             "version": "1.0.0",
@@ -49233,7 +49399,8 @@
             "dev": true
         },
         "is-number": {
-            "version": "7.0.0"
+            "version": "7.0.0",
+            "dev": true
         },
         "is-number-object": {
             "version": "1.0.4",
@@ -49248,7 +49415,8 @@
             "dev": true
         },
         "is-plain-obj": {
-            "version": "2.1.0"
+            "version": "2.1.0",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -49361,6 +49529,7 @@
         },
         "is-wsl": {
             "version": "2.2.0",
+            "dev": true,
             "requires": {
                 "is-docker": "^2.0.0"
             }
@@ -49372,7 +49541,8 @@
             "dev": true
         },
         "isexe": {
-            "version": "2.0.0"
+            "version": "2.0.0",
+            "dev": true
         },
         "isobject": {
             "version": "4.0.0",
@@ -51726,7 +51896,8 @@
             "dev": true
         },
         "js-tokens": {
-            "version": "4.0.0"
+            "version": "4.0.0",
+            "dev": true
         },
         "js-yaml": {
             "version": "3.14.1",
@@ -51843,7 +52014,7 @@
         },
         "klaw-sync": {
             "version": "6.0.0",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11"
             }
@@ -51951,7 +52122,8 @@
             "dev": true
         },
         "lodash.camelcase": {
-            "version": "4.3.0"
+            "version": "4.3.0",
+            "dev": true
         },
         "lodash.debounce": {
             "version": "4.0.8",
@@ -52043,6 +52215,7 @@
         },
         "loose-envify": {
             "version": "1.4.0",
+            "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
@@ -52146,14 +52319,14 @@
         },
         "mdast-add-list-metadata": {
             "version": "1.0.1",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "unist-util-visit-parents": "1.1.2"
             },
             "dependencies": {
                 "unist-util-visit-parents": {
                     "version": "1.1.2",
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -52177,7 +52350,7 @@
         },
         "mdast-util-from-markdown": {
             "version": "0.8.5",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "@types/mdast": "^3.0.0",
                 "mdast-util-to-string": "^2.0.0",
@@ -52204,7 +52377,7 @@
         },
         "mdast-util-to-string": {
             "version": "2.0.0",
-            "peer": true
+            "dev": true
         },
         "mdn-data": {
             "version": "2.0.4",
@@ -52278,7 +52451,7 @@
         },
         "micromark": {
             "version": "2.11.4",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "debug": "^4.0.0",
                 "parse-entities": "^2.0.0"
@@ -52286,6 +52459,7 @@
         },
         "micromatch": {
             "version": "4.0.4",
+            "dev": true,
             "requires": {
                 "braces": "^3.0.1",
                 "picomatch": "^2.2.3"
@@ -52347,6 +52521,7 @@
         },
         "minimatch": {
             "version": "3.0.4",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -52354,7 +52529,8 @@
         "minimist": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
         },
         "minipass": {
             "version": "3.1.6",
@@ -52455,7 +52631,8 @@
             }
         },
         "ms": {
-            "version": "2.1.2"
+            "version": "2.1.2",
+            "dev": true
         },
         "msw": {
             "version": "0.36.8",
@@ -52597,7 +52774,8 @@
             "dev": true
         },
         "nice-try": {
-            "version": "1.0.5"
+            "version": "1.0.5",
+            "dev": true
         },
         "no-case": {
             "version": "3.0.4",
@@ -52869,7 +53047,8 @@
             "dev": true
         },
         "object-assign": {
-            "version": "4.1.1"
+            "version": "4.1.1",
+            "dev": true
         },
         "object-copy": {
             "version": "0.1.0",
@@ -53038,6 +53217,7 @@
         },
         "once": {
             "version": "1.4.0",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -53051,6 +53231,7 @@
         },
         "open": {
             "version": "7.4.2",
+            "dev": true,
             "requires": {
                 "is-docker": "^2.0.0",
                 "is-wsl": "^2.1.1"
@@ -53145,7 +53326,8 @@
             "dev": true
         },
         "os-tmpdir": {
-            "version": "1.0.2"
+            "version": "1.0.2",
+            "dev": true
         },
         "outvariant": {
             "version": "1.2.1",
@@ -53291,6 +53473,7 @@
         },
         "parse-entities": {
             "version": "2.0.0",
+            "dev": true,
             "requires": {
                 "character-entities": "^1.0.0",
                 "character-entities-legacy": "^1.0.0",
@@ -53336,7 +53519,7 @@
         },
         "patch-package": {
             "version": "6.4.7",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "@yarnpkg/lockfile": "^1.1.0",
                 "chalk": "^2.4.2",
@@ -53355,7 +53538,7 @@
             "dependencies": {
                 "cross-spawn": {
                     "version": "6.0.5",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "nice-try": "^1.0.4",
                         "path-key": "^2.0.1",
@@ -53366,7 +53549,7 @@
                 },
                 "fs-extra": {
                     "version": "7.0.1",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
                         "jsonfile": "^4.0.0",
@@ -53375,48 +53558,48 @@
                 },
                 "jsonfile": {
                     "version": "4.0.0",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.6"
                     }
                 },
                 "path-key": {
                     "version": "2.0.1",
-                    "peer": true
+                    "dev": true
                 },
                 "rimraf": {
                     "version": "2.7.1",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "glob": "^7.1.3"
                     }
                 },
                 "semver": {
                     "version": "5.7.1",
-                    "peer": true
+                    "dev": true
                 },
                 "shebang-command": {
                     "version": "1.2.0",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "shebang-regex": "^1.0.0"
                     }
                 },
                 "shebang-regex": {
                     "version": "1.0.0",
-                    "peer": true
+                    "dev": true
                 },
                 "slash": {
                     "version": "2.0.0",
-                    "peer": true
+                    "dev": true
                 },
                 "universalify": {
                     "version": "0.1.2",
-                    "peer": true
+                    "dev": true
                 },
                 "which": {
                     "version": "1.3.1",
-                    "peer": true,
+                    "dev": true,
                     "requires": {
                         "isexe": "^2.0.0"
                     }
@@ -53436,7 +53619,8 @@
             "dev": true
         },
         "path-is-absolute": {
-            "version": "1.0.1"
+            "version": "1.0.1",
+            "dev": true
         },
         "path-key": {
             "version": "3.1.1",
@@ -53472,7 +53656,8 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.3.0"
+            "version": "2.3.0",
+            "dev": true
         },
         "pidtree": {
             "version": "0.3.1",
@@ -54711,6 +54896,7 @@
         },
         "prop-types": {
             "version": "15.7.2",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -54902,6 +55088,7 @@
         },
         "react": {
             "version": "16.14.0",
+            "dev": true,
             "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0",
@@ -54911,7 +55098,7 @@
         },
         "react-clientside-effect": {
             "version": "1.2.5",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.12.13"
             }
@@ -54979,6 +55166,7 @@
         },
         "react-dom": {
             "version": "16.14.0",
+            "dev": true,
             "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0",
@@ -55030,7 +55218,7 @@
         },
         "react-focus-lock": {
             "version": "2.7.1",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.0.0",
                 "focus-lock": "^0.10.1",
@@ -55042,7 +55230,7 @@
             "dependencies": {
                 "use-callback-ref": {
                     "version": "1.2.5",
-                    "peer": true,
+                    "dev": true,
                     "requires": {}
                 }
             }
@@ -55070,11 +55258,12 @@
             }
         },
         "react-is": {
-            "version": "16.13.1"
+            "version": "16.13.1",
+            "dev": true
         },
         "react-keyed-flatten-children": {
             "version": "1.3.0",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "react-is": "^16.8.6"
             }
@@ -55318,36 +55507,6 @@
                 "picomatch": "^2.2.1"
             }
         },
-        "reakit": {
-            "version": "1.3.0",
-            "peer": true,
-            "requires": {
-                "@popperjs/core": "^2.4.4",
-                "body-scroll-lock": "^3.1.5",
-                "reakit-system": "^0.15.0",
-                "reakit-utils": "^0.15.0",
-                "reakit-warning": "^0.6.0"
-            }
-        },
-        "reakit-system": {
-            "version": "0.15.2",
-            "peer": true,
-            "requires": {
-                "reakit-utils": "^0.15.2"
-            }
-        },
-        "reakit-utils": {
-            "version": "0.15.2",
-            "peer": true,
-            "requires": {}
-        },
-        "reakit-warning": {
-            "version": "0.6.2",
-            "peer": true,
-            "requires": {
-                "reakit-utils": "^0.15.2"
-            }
-        },
         "redent": {
             "version": "3.0.0",
             "dev": true,
@@ -55390,7 +55549,8 @@
             }
         },
         "regenerator-runtime": {
-            "version": "0.13.7"
+            "version": "0.13.7",
+            "dev": true
         },
         "regenerator-transform": {
             "version": "0.14.5",
@@ -56506,6 +56666,7 @@
         },
         "scheduler": {
             "version": "0.19.1",
+            "dev": true,
             "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0",
@@ -57333,6 +57494,7 @@
         },
         "supports-color": {
             "version": "5.5.0",
+            "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
             }
@@ -57706,10 +57868,11 @@
         },
         "tiny-warning": {
             "version": "1.0.3",
-            "peer": true
+            "dev": true
         },
         "tmp": {
             "version": "0.0.33",
+            "dev": true,
             "requires": {
                 "os-tmpdir": "~1.0.2"
             }
@@ -57758,6 +57921,7 @@
         },
         "to-regex-range": {
             "version": "5.0.1",
+            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -57809,7 +57973,8 @@
             "dev": true
         },
         "trough": {
-            "version": "1.0.5"
+            "version": "1.0.5",
+            "dev": true
         },
         "ts-dedent": {
             "version": "2.2.0",
@@ -58097,6 +58262,7 @@
         },
         "unified": {
             "version": "9.2.0",
+            "dev": true,
             "requires": {
                 "bail": "^1.0.0",
                 "extend": "^3.0.0",
@@ -58157,7 +58323,8 @@
             "dev": true
         },
         "unist-util-is": {
-            "version": "4.1.0"
+            "version": "4.1.0",
+            "dev": true
         },
         "unist-util-position": {
             "version": "3.1.0",
@@ -58185,12 +58352,14 @@
         },
         "unist-util-stringify-position": {
             "version": "2.0.3",
+            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.2"
             }
         },
         "unist-util-visit": {
             "version": "2.0.3",
+            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
                 "unist-util-is": "^4.0.0",
@@ -58199,6 +58368,7 @@
         },
         "unist-util-visit-parents": {
             "version": "3.1.1",
+            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
                 "unist-util-is": "^4.0.0"
@@ -58346,7 +58516,7 @@
         },
         "use-sidecar": {
             "version": "1.0.5",
-            "peer": true,
+            "dev": true,
             "requires": {
                 "detect-node-es": "^1.1.0",
                 "tslib": "^1.9.3"
@@ -58354,7 +58524,7 @@
             "dependencies": {
                 "tslib": {
                     "version": "1.14.1",
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -58442,6 +58612,7 @@
         },
         "vfile": {
             "version": "4.2.1",
+            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
                 "is-buffer": "^2.0.0",
@@ -58457,6 +58628,7 @@
         },
         "vfile-message": {
             "version": "2.0.4",
+            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
                 "unist-util-stringify-position": "^2.0.0"
@@ -59259,7 +59431,8 @@
             }
         },
         "wrappy": {
-            "version": "1.0.2"
+            "version": "1.0.2",
+            "dev": true
         },
         "write-file-atomic": {
             "version": "3.0.3",
@@ -59285,7 +59458,8 @@
             "dev": true
         },
         "xtend": {
-            "version": "4.0.2"
+            "version": "4.0.2",
+            "dev": true
         },
         "y18n": {
             "version": "4.0.1",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -46,6 +46,7 @@
         "dayjs": "^1.9.1"
     },
     "devDependencies": {
+        "@doist/reactist": "^12.0.1",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-essentials": "^6.3.12",
         "@storybook/addon-links": "^6.3.12",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -35,10 +35,10 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^11.0.0",
+        "@doist/reactist": "^12.0.0",
         "@doist/ui-extensions-core": "^3.1.4",
         "adaptivecards": "^2.9.0",
-        "react": ">=16"
+        "react": ">=17"
     },
     "prettier": "@doist/prettier-config",
     "dependencies": {

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -55,10 +55,10 @@
         "@testing-library/react-hooks": "^3.3.0",
         "eslint-config-react-app": "^7.0.0",
         "msw": "^0.36.8",
-        "react": "^16.14.0",
-        "react-dom": "^16.14.0",
-        "react-is": "^16.13.1",
-        "react-test-renderer": "^16.13.1"
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "react-is": "^17.0.2",
+        "react-test-renderer": "^17.0.2"
     },
     "msw": {
         "workerDirectory": "src/stories/public"


### PR DESCRIPTION
This is needed in order to bring Reactist v12 to Todoist and Twist, as well as extensions-renderers.

I don't have permissions to this repo so working off a fork for now.

One thing I couldn't figure out is that React v16 is still pulled down by `@testing-library/react-hooks@7` and `@testing-library/react@12`, even though both have React listed as `<18.0.0` under peerDependencies. This causes tests to end up with two copies of React and fail. I'll have to take another look tonight.

## Reference

https://github.com/Doist/reactist/releases/tag/v12.0.1
https://github.com/Doist/reactist/releases/tag/v12.0.0