### PR TITLE
chore: Bump Reactist to v13

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -20,6 +20,8 @@ jobs:
 
             - name: Bootstrap
               run: npm run bootstrap-ci:common
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.GH_PACKAGES_TOKEN}}
 
             - name: Integrity Check
               run: npm run integrity-check

--- a/.github/workflows/react-ci.yml
+++ b/.github/workflows/react-ci.yml
@@ -20,6 +20,8 @@ jobs:
 
             - name: Bootstrap
               run: npm run bootstrap-ci:react
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.GH_PACKAGES_TOKEN}}
 
             - name: Integrity Check
               run: npm run integrity-check

--- a/package-lock.json
+++ b/package-lock.json
@@ -2226,11 +2226,10 @@
         },
         "node_modules/@doist/reactist": {
             "version": "13.0.0",
-            "resolved": "https://npm.pkg.github.com/download/@Doist/reactist/13.0.0/10821aebaf83126d21a399a6e254f1c0c5831491",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-13.0.0.tgz",
             "integrity": "sha512-f7Rusw2sh0DdmjPCz8MyPro4TjDZjYJSwxlZLpKFlNnfLRXvGpNWl1wQBmZHsIDAwhELiAHCa2AEjsqaYqPuUw==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "dependencies": {
                 "@reach/dialog": "^0.16.0",
                 "ariakit": "^2.0.0-next.27",
@@ -28822,7 +28821,7 @@
                 "dayjs": "^1.9.1"
             },
             "devDependencies": {
-                "@doist/reactist": "13.0.0",
+                "@doist/reactist": "^13.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -30821,7 +30820,7 @@
         },
         "@doist/reactist": {
             "version": "13.0.0",
-            "resolved": "https://npm.pkg.github.com/download/@Doist/reactist/13.0.0/10821aebaf83126d21a399a6e254f1c0c5831491",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-13.0.0.tgz",
             "integrity": "sha512-f7Rusw2sh0DdmjPCz8MyPro4TjDZjYJSwxlZLpKFlNnfLRXvGpNWl1wQBmZHsIDAwhELiAHCa2AEjsqaYqPuUw==",
             "dev": true,
             "requires": {
@@ -30918,7 +30917,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
-                "@doist/reactist": "13.0.0",
+                "@doist/reactist": "^13.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28815,7 +28815,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "3.2.0",
+            "version": "4.0.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2225,11 +2225,12 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-12.0.1.tgz",
-            "integrity": "sha512-iFC7AcclICkvn6GYz3VbBI4K27mj9Lt23LXaG8QsuNuQ8o/whOhkUuH499hj57Fk/ifrAzpf6XXg757+6WhwOA==",
+            "version": "13.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@Doist/reactist/13.0.0/10821aebaf83126d21a399a6e254f1c0c5831491",
+            "integrity": "sha512-f7Rusw2sh0DdmjPCz8MyPro4TjDZjYJSwxlZLpKFlNnfLRXvGpNWl1wQBmZHsIDAwhELiAHCa2AEjsqaYqPuUw==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "dependencies": {
                 "@reach/dialog": "^0.16.0",
                 "ariakit": "^2.0.0-next.27",
@@ -28821,7 +28822,7 @@
                 "dayjs": "^1.9.1"
             },
             "devDependencies": {
-                "@doist/reactist": "^12.0.1",
+                "@doist/reactist": "13.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -28842,7 +28843,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^12.0.0",
+                "@doist/reactist": "^13.0.0",
                 "@doist/ui-extensions-core": "^3.2.1",
                 "adaptivecards": "^2.9.0",
                 "react": ">=17"
@@ -30819,9 +30820,9 @@
             "requires": {}
         },
         "@doist/reactist": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-12.0.1.tgz",
-            "integrity": "sha512-iFC7AcclICkvn6GYz3VbBI4K27mj9Lt23LXaG8QsuNuQ8o/whOhkUuH499hj57Fk/ifrAzpf6XXg757+6WhwOA==",
+            "version": "13.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@Doist/reactist/13.0.0/10821aebaf83126d21a399a6e254f1c0c5831491",
+            "integrity": "sha512-f7Rusw2sh0DdmjPCz8MyPro4TjDZjYJSwxlZLpKFlNnfLRXvGpNWl1wQBmZHsIDAwhELiAHCa2AEjsqaYqPuUw==",
             "dev": true,
             "requires": {
                 "@reach/dialog": "^0.16.0",
@@ -30917,7 +30918,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
-                "@doist/reactist": "^12.0.1",
+                "@doist/reactist": "13.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^12.0.0",
+        "@doist/reactist": "^13.0.0",
         "@doist/ui-extensions-core": "^3.2.1",
         "adaptivecards": "^2.9.0",
         "react": ">=17"
@@ -46,7 +46,7 @@
         "dayjs": "^1.9.1"
     },
     "devDependencies": {
-        "@doist/reactist": "^12.0.1",
+        "@doist/reactist": "13.0.0",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-essentials": "^6.3.12",
         "@storybook/addon-links": "^6.3.12",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -46,7 +46,7 @@
         "dayjs": "^1.9.1"
     },
     "devDependencies": {
-        "@doist/reactist": "13.0.0",
+        "@doist/reactist": "^13.0.0",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-essentials": "^6.3.12",
         "@storybook/addon-links": "^6.3.12",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "3.2.0",
+    "version": "4.0.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",


### PR DESCRIPTION
This upgrades Reactist to [v13.0.0](https://github.com/Doist/reactist/releases/tag/v13.0.0). 

While the breaking changes shouldn't affect anything here, a major version should be released as it will force consuming apps to install the newer version. Ref: https://github.com/semver/semver/issues/502