### PR TITLE
chore: Adds a new bridge for internal use only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28809,7 +28809,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",

--- a/packages/ui-extensions-react/src/types/types.ts
+++ b/packages/ui-extensions-react/src/types/types.ts
@@ -1,7 +1,7 @@
 import type {
     DoistCard,
     DoistCardAction,
-    DoistCardBridge,
+    DoistCardBridge as OriginalDoistCardBridge,
     DoistCardBridgeActionType,
     DoistCardContext,
     DoistCardError,
@@ -30,6 +30,11 @@ export type DoistCardResult =
     | { type: 'loaded'; card: ExtensionCard }
     | { type: 'error'; error: ExtensionError }
 
+type AllBridgeActionTypes = DoistCardBridgeActionType | 'consent.required'
+export type DoistCardBridge = OriginalDoistCardBridge & {
+    scopes?: string
+}
+
 export type BridgeActionCallbacks = Partial<
-    Record<DoistCardBridgeActionType, (action: DoistCardBridge) => unknown>
+    Record<AllBridgeActionTypes, (action: DoistCardBridge) => unknown>
 >


### PR DESCRIPTION
On our apps, we need to handle an internal-only bridge called `consent.required` and is sent back by the dispatch proxy (on Todoist only right now, but Twist will follow), which will tell the apps to display a consent prompt to allow the extension to be given a token with the specified scopes.

I'm adding this new bridge directly, and only, in the react package as this isn't something that should be in the `ui-extensions-core` package for 3rd party devs to use.