### PR TITLE
feat: Adds `fromWithItems()` and `fromWithActions()` helper functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28801,7 +28801,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/src/doist-card/containers.test.ts
+++ b/packages/ui-extensions-core/src/doist-card/containers.test.ts
@@ -1,4 +1,5 @@
 import { SubmitAction } from './actions'
+import { TextBlock } from './card-elements'
 import { ActionSet, Column, Container } from './containers'
 import { SizeAndUnit } from './shared'
 
@@ -47,6 +48,17 @@ describe('containers', () => {
                 type: 'Column',
                 items: [],
                 width: 'stretch',
+            })
+        })
+
+        it('serialises items when added via `fromWithItems()`', () => {
+            const column = Column.fromWithItems({
+                items: [TextBlock.from({ text: 'kwijibo' })],
+            })
+
+            expect(JSON.parse(JSON.stringify(column))).toMatchObject({
+                type: 'Column',
+                items: [{ text: 'kwijibo', type: 'TextBlock' }],
             })
         })
     })
@@ -102,6 +114,19 @@ describe('containers', () => {
 
                 const result = container.getActionById('TheId')
                 expect(result).not.toBeUndefined()
+            })
+        })
+    })
+
+    describe('ActionSet', () => {
+        it('serialises actions correctly when created using `fromWithActions()`', () => {
+            const actionSet = ActionSet.fromWithActions({
+                actions: [SubmitAction.from({ title: 'kwijibo' })],
+            })
+
+            expect(JSON.parse(JSON.stringify(actionSet))).toMatchObject({
+                type: 'ActionSet',
+                actions: [{ title: 'kwijibo', type: 'Action.Submit' }],
             })
         })
     })

--- a/packages/ui-extensions-core/src/doist-card/containers.ts
+++ b/packages/ui-extensions-core/src/doist-card/containers.ts
@@ -4,6 +4,7 @@ import { Action } from './actions'
 import { CardElement } from './card-element'
 import { SerializableObject } from './serialization'
 
+import type { Props } from './props'
 import type {
     ColumnWidth,
     ContainerStyle,
@@ -162,6 +163,19 @@ export class Container extends ContainerWithNoItems {
     protected getJsonTypeName(): string {
         return 'Container'
     }
+
+    static fromWithItems<T extends Container>(
+        this: new () => T,
+        props: Props<T> & { items?: CardElement[] },
+    ): T {
+        const o = new this()
+        const { items, ...rest } = props
+        Object.assign(o, rest)
+        if (items && items.length > 0) {
+            items.forEach((item) => o.addItem(item))
+        }
+        return o
+    }
 }
 
 @Serializable()
@@ -215,6 +229,19 @@ export class ActionSet extends CardElement {
         }
 
         return result
+    }
+
+    static fromWithActions<T extends ActionSet>(
+        this: new () => T,
+        props: Props<T> & { actions?: Action[] },
+    ): T {
+        const o = new this()
+        const { actions, ...rest } = props
+        Object.assign(o, rest)
+        if (actions && actions.length > 0) {
+            actions.forEach((action) => o.addAction(action))
+        }
+        return o
     }
 }
 


### PR DESCRIPTION
This allows us to create, for example, a Column in the following fashion

``` typescript
const column = Column.fromWithItems({
    items: [TextBlock.from({ text: 'kwijibo' })],
})
```
rather than the more cumbersome
``` typescript
const column = new Column()
column.addItem(TextBlock.from({text: 'hello'}))
column.addItem(TextBlock.from({text: 'world'}))
```