### PR TITLE
feat: UI Extension changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28801,7 +28801,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "4.0.0-alpha.0",
+            "version": "4.0.0",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"
@@ -28809,7 +28809,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "7.0.0-alpha.0",
+            "version": "7.0.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
@@ -28838,7 +28838,7 @@
             },
             "peerDependencies": {
                 "@doist/reactist": "^15.0.0",
-                "@doist/ui-extensions-core": "^4.0.0-alpha.0",
+                "@doist/ui-extensions-core": "^4.0.0",
                 "adaptivecards": "^2.9.0",
                 "react": ">=17"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28801,7 +28801,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "4.0.0-alpha.2",
+            "version": "4.0.0-alpha.3",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28801,7 +28801,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "4.0.0-alpha.3",
+            "version": "4.0.0-alpha.4",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28801,7 +28801,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "3.3.0",
+            "version": "4.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"
@@ -28809,7 +28809,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "6.1.0",
+            "version": "7.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
@@ -28838,7 +28838,7 @@
             },
             "peerDependencies": {
                 "@doist/reactist": "^15.0.0",
-                "@doist/ui-extensions-core": "^3.2.1",
+                "@doist/ui-extensions-core": "^4.0.0-alpha.0",
                 "adaptivecards": "^2.9.0",
                 "react": ">=17"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28801,7 +28801,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "4.0.0",
+            "version": "4.0.0-alpha.1",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"
@@ -28838,7 +28838,7 @@
             },
             "peerDependencies": {
                 "@doist/reactist": "^15.0.0",
-                "@doist/ui-extensions-core": "^4.0.0",
+                "@doist/ui-extensions-core": "^4.0.0-alpha.1",
                 "adaptivecards": "^2.9.0",
                 "react": ">=17"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28801,7 +28801,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "4.0.0-alpha.4",
+            "version": "4.0.0",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"
@@ -28809,7 +28809,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "7.0.0-alpha.0",
+            "version": "7.0.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
@@ -28838,7 +28838,7 @@
             },
             "peerDependencies": {
                 "@doist/reactist": "^15.0.0",
-                "@doist/ui-extensions-core": "^4.0.0-alpha.1",
+                "@doist/ui-extensions-core": "^4.0.0",
                 "adaptivecards": "^2.9.0",
                 "react": ">=17"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28801,7 +28801,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "4.0.0-alpha.1",
+            "version": "4.0.0-alpha.2",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"
@@ -28809,7 +28809,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "7.0.0",
+            "version": "7.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "3.3.0",
+    "version": "4.0.0-alpha.0",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "4.0.0-alpha.4",
+    "version": "4.0.0",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "4.0.0",
+    "version": "4.0.0-alpha.1",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "4.0.0-alpha.0",
+    "version": "4.0.0",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "4.0.0-alpha.1",
+    "version": "4.0.0-alpha.2",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "4.0.0-alpha.3",
+    "version": "4.0.0-alpha.4",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "4.0.0-alpha.2",
+    "version": "4.0.0-alpha.3",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/src/doist-card/actions.ts
+++ b/packages/ui-extensions-core/src/doist-card/actions.ts
@@ -28,6 +28,9 @@ export class SubmitAction extends Action {
     @JsonProperty()
     data?: PropertyBag
 
+    @JsonProperty()
+    loadingText?: string
+
     protected getJsonTypeName(): string {
         return 'Action.Submit'
     }

--- a/packages/ui-extensions-core/src/doist-card/card-elements.ts
+++ b/packages/ui-extensions-core/src/doist-card/card-elements.ts
@@ -4,6 +4,7 @@ import { Action } from './actions'
 import { CardElement } from './card-element'
 import { ContainerWithNoItems } from './containers'
 
+import type { Props } from './props'
 import type {
     DoistCardVersion,
     FontSize,
@@ -102,6 +103,19 @@ export class DoistCard extends ContainerWithNoItems {
         }
 
         return result
+    }
+
+    static fromWithItems<T extends DoistCard>(
+        this: new () => T,
+        props: Props<T> & { items?: CardElement[] },
+    ): T {
+        const o = new this()
+        const { items, ...rest } = props
+        Object.assign(o, rest)
+        if (items && items.length > 0) {
+            items.forEach((item) => o.addItem(item))
+        }
+        return o
     }
 }
 

--- a/packages/ui-extensions-core/src/index.ts
+++ b/packages/ui-extensions-core/src/index.ts
@@ -1,2 +1,3 @@
-export * from './doist-card/'
+export * from './doist-card'
 export * from './types'
+export * from './ui-helpers'

--- a/packages/ui-extensions-core/src/types/bridges.ts
+++ b/packages/ui-extensions-core/src/types/bridges.ts
@@ -1,0 +1,70 @@
+/**
+ * Types of actions that the server can invoke on the client via a bridge.
+ */
+export type DoistCardBridgeActionType = DoistCardBridge['bridgeActionType']
+
+/**
+ * The notification display type
+ */
+export type DoistCardNotificationType = 'success' | 'error' | 'info'
+
+/**
+ * The bridge notification. This should be supplied when the `bridgeActionType` is `display.notification`
+ */
+export type DoistCardBridgeNotification = {
+    /**
+     * The text that should appear in the notification.
+     *
+     * NOTE: this should be plain text, Markdown is *not* supported
+     */
+    text: string
+    type: DoistCardNotificationType
+    /**
+     * The action, this should be a URL and is what will be launched when clicked (if provided)
+     */
+    actionUrl?: string
+    /**
+     * This is the text that will be displayed as the notification action, clicking it will take you to
+     * what has been assigned to `actionUrl`
+     */
+    actionText?: string
+}
+
+/**
+ * The bridge action that closes the UI extension within Twist/Todoist.
+ */
+export type FinishedBridge = {
+    bridgeActionType: 'finished'
+}
+
+/**
+ * The bridge action that inserts text into the relevant text input field.
+ */
+export type ComposerAppendBridge = {
+    bridgeActionType: 'composer.append'
+    text: string
+}
+
+/**
+ * The bridge action that displays a notification and optional action. The action will open a URL in the browser.
+ */
+export type DisplayNotificationBridge = {
+    bridgeActionType: 'display.notification'
+    notification: DoistCardBridgeNotification
+}
+
+export type RequestTodoistSyncBridge = {
+    bridgeActionType: 'request.sync'
+    onSuccessNotification?: DoistCardBridgeNotification
+    onErrorNotification?: DoistCardBridgeNotification
+}
+
+/**
+ * The bridge represents actions that the server asks the client to invoke locally,
+ * along with necessary parameters to do so.
+ */
+export type DoistCardBridge =
+    | FinishedBridge
+    | ComposerAppendBridge
+    | DisplayNotificationBridge
+    | RequestTodoistSyncBridge

--- a/packages/ui-extensions-core/src/types/bridges.ts
+++ b/packages/ui-extensions-core/src/types/bridges.ts
@@ -53,6 +53,10 @@ export type DisplayNotificationBridge = {
     notification: DoistCardBridgeNotification
 }
 
+/**
+ * The bridge action that will trigger a sync request in Todoist. The bridge accepts notifications
+ * for both success, and error, scenarios.
+ */
 export type RequestTodoistSyncBridge = {
     bridgeActionType: 'request.sync'
     onSuccessNotification?: DoistCardBridgeNotification

--- a/packages/ui-extensions-core/src/types/data-exchange.ts
+++ b/packages/ui-extensions-core/src/types/data-exchange.ts
@@ -1,4 +1,7 @@
 import type { DoistCard } from '../doist-card'
+import type { DoistCardBridge } from './bridges'
+import type { TodoistContext, TodoistContextMenuSource } from './todoist'
+import type { TwistContext, TwistContextMenuSource } from './twist'
 
 /**
  * The types of actions that an adaptive card integration can request.
@@ -21,11 +24,10 @@ export type DoistCardActionParams = Record<string, unknown>
  */
 export type DoistCardActionData = Record<string, unknown>
 
+/**
+ * The different extension types that are currently available.
+ */
 export type DoistCardExtensionType = 'composer' | 'context-menu' | `settings`
-
-export type TwistContextMenuSource = 'message' | 'thread' | 'comment'
-
-export type TodoistContextMenuSource = 'project' | 'task'
 
 /**
  * When a context menu extension is triggered, the data will be sent in the
@@ -40,7 +42,7 @@ export type ContextMenuData = {
     /**
      * The id of the source object
      */
-    sourceId: number
+    sourceId: number | string
     /**
      * The content that has been sent with the request. This could be
      * a conversation message, thread comment, or thread title
@@ -116,93 +118,9 @@ export type DoistCardContextUser = {
     email: string
 }
 
-/**
- * The workspace where the user is currently browsing content.
- */
-export type DoistCardContextWorkspace = {
-    id: number
-    name: string
-}
-
-/**
- * The current channel in which the user is browsing content. Is not present in the data if the user is not currently browsing a channel.
- */
-export type DoistCardContextChannel = {
-    id: number
-    name: string
-    description: string
-}
-
-/**
- * The current thread in which the user is browsing content. Is not present in the data if the user is not currently browsing a thread.
- */
-export type DoistCardContextThread = {
-    id: number
-    title: string
-}
-
-/**
- * The current conversation in which the user is browsing content. Is not present in the data if the user is not currently browsing a a conversation.
- */
-export type DoistCardContextConversation = {
-    id: number
-    title: string
-}
-
-type IdAndName = { id: number; name: string }
-
-/**
- * The current project in which the user is browsing content. Is not present in the data if the user is not currently browsing a project.
- */
-export type DoistCardContextProject = IdAndName
-
-/**
- * The current label in which the user is browsing content. Is not present in the data if the user is not currently browsing a label.
- */
-export type DoistCardContextLabel = IdAndName
-
-/**
- * The current filter in which the user is browsing content. Is not present in the data if the user is not currently browsing a filter.
- */
-export type DoistCardContextFilter = IdAndName
-
-type Message = {
-    id: number
-    content: string
-    posted: Date
-}
-
-export type DoistCardContextMessage = Message
-
-export type DoistCardContextComment = Message
-
 export type Theme = 'light' | 'dark'
 
 export type Platform = 'desktop' | 'mobile'
-
-/**
- * Context on which interactions with the adaptive card integration happen.
- */
-export type TwistContext = {
-    workspace: DoistCardContextWorkspace
-    channel?: DoistCardContextChannel
-    thread?: DoistCardContextThread
-    conversation?: DoistCardContextConversation
-    message?: DoistCardContextMessage
-    comment?: DoistCardContextComment
-}
-
-/**
- * Context from Todoist on which interactions with the adaptive card integration happen.
- */
-export type TodoistContext = {
-    /**
-     * Project may not exist as Todoist could be on Today/Upcoming/Filters
-     */
-    project?: DoistCardContextProject
-    filter?: DoistCardContextFilter
-    label?: DoistCardContextLabel
-}
 
 export type DoistCardContext = {
     user: DoistCardContextUser
@@ -227,48 +145,6 @@ export type DoistCardRequest = {
 }
 
 /**
- * Types of actions that the server can invoke on the client via a bridge.
- */
-export type DoistCardBridgeActionType = 'composer.append' | 'finished' | 'display.notification'
-
-/**
- * The notification display type
- */
-export type DoistCardNotificationType = 'success' | 'error' | 'info'
-
-/**
- * The bridge notification. This should be supplied when the `bridgeActionType` is `display.notification`
- */
-export type DoistCardBridgeNotification = {
-    /**
-     * The text that should appear in the notification.
-     *
-     * NOTE: this should be plain text, Markdown is *not* supported
-     */
-    text: string
-    type: DoistCardNotificationType
-    /**
-     * The action, this should be a URL and is what will be launched when clicked (if provided)
-     */
-    actionUrl?: string
-    /**
-     * This is the text that will be displayed as the notification action, clicking it will take you to
-     * what has been assigned to `actionUrl`
-     */
-    actionText?: string
-}
-
-/**
- * The bridge represents actions that the server asks the client to invoke locally,
- * along with necessary parameters to do so.
- */
-export type DoistCardBridge = {
-    bridgeActionType: DoistCardBridgeActionType
-    text?: string
-    notification?: DoistCardBridgeNotification
-}
-
-/**
  * A top-level object representing a response by the server agains the integration client.
  */
 export type DoistCardResponse = {
@@ -279,6 +155,5 @@ export type DoistCardResponse = {
 export type DoistCardError = {
     error: Error
     request?: DoistCardRequest
-    bridge?: DoistCardBridge
     bridges?: DoistCardBridge[]
 }

--- a/packages/ui-extensions-core/src/types/data-exchange.ts
+++ b/packages/ui-extensions-core/src/types/data-exchange.ts
@@ -1,7 +1,7 @@
 import type { DoistCard } from '../doist-card'
 import type { DoistCardBridge } from './bridges'
-import type { TodoistContext, TodoistContextMenuSource } from './todoist'
-import type { TwistContext, TwistContextMenuSource } from './twist'
+import type { TodoistContext, TodoistContextMenuData } from './todoist'
+import type { TwistContext, TwistContextMenuData } from './twist'
 
 /**
  * The types of actions that an adaptive card integration can request.
@@ -34,51 +34,7 @@ export type DoistCardExtensionType = 'composer' | 'context-menu' | `settings`
  * `params` field of the `DoistCardAction`. This type will allow you to
  * cast that data to something specific.
  */
-export type ContextMenuData = {
-    /**
-     * The deep link back to the source
-     */
-    url: string
-    /**
-     * The id of the source object
-     */
-    sourceId: number | string
-    /**
-     * The content that has been sent with the request. This could be
-     * a conversation message, thread comment, or thread title
-     */
-    content: string
-    /**
-     * The content that has been sent with the request. This could be
-     * a conversation message, thread comment, or thread title, only this
-     * has been scrubbed of all markdown formatting.
-     */
-    contentPlain: string
-} & (
-    | {
-          /**
-           * The source that made the request to the extension
-           */
-          source: TwistContextMenuSource
-          /**
-           * The date the content was posted. For threads, this will be the
-           * date the thread was created.
-           */
-          postedDate: Date
-      }
-    | {
-          /**
-           * The source that made the request to the extension
-           */
-          source: TodoistContextMenuSource
-
-          /**
-           * The date the content was posted. For projects, this will be null.
-           * For tasks this will be the date the task was created.
-           */
-          postedDate?: Date
-      }
-)
+export type ContextMenuData = TodoistContextMenuData | TwistContextMenuData
 
 /**
  * Represents an action that the user has done on the client.

--- a/packages/ui-extensions-core/src/types/index.ts
+++ b/packages/ui-extensions-core/src/types/index.ts
@@ -1,1 +1,4 @@
+export * from './bridges'
 export * from './data-exchange'
+export * from './todoist'
+export * from './twist'

--- a/packages/ui-extensions-core/src/types/todoist.ts
+++ b/packages/ui-extensions-core/src/types/todoist.ts
@@ -30,4 +30,42 @@ export type TodoistContext = {
     }
 }
 
+/**
+ * When a context menu extension is triggered, the data will be sent in the
+ * `params` field of the `DoistCardAction`. This type will allow you to
+ * cast that data to something specific.
+ */
+export type TodoistContextMenuData = {
+    /**
+     * The deep link back to the source
+     */
+    url: string
+    /**
+     * The id of the source object
+     */
+    sourceId: string
+    /**
+     * The content that has been sent with the request. This could be
+     * a conversation message, thread comment, or thread title
+     */
+    content: string
+    /**
+     * The content that has been sent with the request. This could be
+     * a conversation message, thread comment, or thread title, only this
+     * has been scrubbed of all markdown formatting.
+     */
+    contentPlain: string
+
+    /**
+     * The source that made the request to the extension
+     */
+    source: TodoistContextMenuSource
+
+    /**
+     * The date the content was posted. For projects, this will be null.
+     * For tasks this will be the date the task was created.
+     */
+    postedDate?: Date
+}
+
 export type TodoistContextMenuSource = 'project' | 'task'

--- a/packages/ui-extensions-core/src/types/todoist.ts
+++ b/packages/ui-extensions-core/src/types/todoist.ts
@@ -1,0 +1,33 @@
+type TodoistIdAndName = { id: string; name: string }
+
+/**
+ * The current project in which the user is browsing content. Is not present in the data if the user is not currently browsing a project.
+ */
+export type TodoistContextProject = TodoistIdAndName
+
+/**
+ * The current label in which the user is browsing content. Is not present in the data if the user is not currently browsing a label.
+ */
+export type TodoistContextLabel = TodoistIdAndName
+
+/**
+ * The current filter in which the user is browsing content. Is not present in the data if the user is not currently browsing a filter.
+ */
+export type TodoistContextFilter = TodoistIdAndName
+
+/**
+ * Context from Todoist on which interactions with the adaptive card integration happen.
+ */
+export type TodoistContext = {
+    /**
+     * Project may not exist as Todoist could be on Today/Upcoming/Filters
+     */
+    project?: TodoistContextProject
+    filter?: TodoistContextFilter
+    label?: TodoistContextLabel
+    additionalUserContext: {
+        isPro: boolean
+    }
+}
+
+export type TodoistContextMenuSource = 'project' | 'task'

--- a/packages/ui-extensions-core/src/types/twist.ts
+++ b/packages/ui-extensions-core/src/types/twist.ts
@@ -1,0 +1,56 @@
+/**
+ * Context on which interactions with the adaptive card integration happen.
+ */
+export type TwistContext = {
+    workspace: TwistContextWorkspace
+    channel?: TwistContextChannel
+    thread?: TwistContextThread
+    conversation?: TwistContextConversation
+    message?: TwistContextMessage
+    comment?: TwistContextComment
+}
+
+/**
+ * The workspace where the user is currently browsing content.
+ */
+export type TwistContextWorkspace = {
+    id: number
+    name: string
+}
+
+/**
+ * The current channel in which the user is browsing content. Is not present in the data if the user is not currently browsing a channel.
+ */
+export type TwistContextChannel = {
+    id: number
+    name: string
+    description: string
+}
+
+/**
+ * The current thread in which the user is browsing content. Is not present in the data if the user is not currently browsing a thread.
+ */
+export type TwistContextThread = {
+    id: number
+    title: string
+}
+
+/**
+ * The current conversation in which the user is browsing content. Is not present in the data if the user is not currently browsing a a conversation.
+ */
+export type TwistContextConversation = {
+    id: number
+    title: string
+}
+
+type TwistMessage = {
+    id: number
+    content: string
+    posted: Date
+}
+
+export type TwistContextMessage = TwistMessage
+
+export type TwistContextComment = TwistMessage
+
+export type TwistContextMenuSource = 'message' | 'thread' | 'comment'

--- a/packages/ui-extensions-core/src/types/twist.ts
+++ b/packages/ui-extensions-core/src/types/twist.ts
@@ -54,3 +54,41 @@ export type TwistContextMessage = TwistMessage
 export type TwistContextComment = TwistMessage
 
 export type TwistContextMenuSource = 'message' | 'thread' | 'comment'
+
+/**
+ * When a context menu extension is triggered, the data will be sent in the
+ * `params` field of the `DoistCardAction`. This type will allow you to
+ * cast that data to something specific.
+ */
+export type TwistContextMenuData = {
+    /**
+     * The deep link back to the source
+     */
+    url: string
+    /**
+     * The id of the source object
+     */
+    sourceId: number
+    /**
+     * The content that has been sent with the request. This could be
+     * a conversation message, thread comment, or thread title
+     */
+    content: string
+    /**
+     * The content that has been sent with the request. This could be
+     * a conversation message, thread comment, or thread title, only this
+     * has been scrubbed of all markdown formatting.
+     */
+    contentPlain: string
+
+    /**
+     * The source that made the request to the extension
+     */
+    source: TwistContextMenuSource
+
+    /**
+     * The date the content was posted. For threads, this will be the
+     * date the thread was created.
+     */
+    postedDate: Date
+}

--- a/packages/ui-extensions-core/src/ui-helpers/button-helpers.test.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/button-helpers.test.ts
@@ -1,0 +1,51 @@
+import { createTextButton } from './button-helpers'
+
+import type { Container, OpenUrlAction, SubmitAction, TextBlock } from '../doist-card'
+
+describe('button-helpers', () => {
+    describe('createTextButton', () => {
+        it('creates correct elements when url provided', () => {
+            const result = createTextButton({
+                text: 'Go back',
+                color: 'warning',
+                url: 'https://kwijibo.com',
+            })
+
+            // We get the textblock like this rather than by id, because fixing the id
+            // would be bad as a card could use this method a number of times, and end up with
+            // a number of items all with the same id.
+            const text = (result as Container).getItemAt(0) as TextBlock
+
+            // Text checks
+            expect(text.text).toEqual('Go back')
+            expect(text.color).toEqual('warning')
+
+            // Action checks
+            expect(((result as Container).selectAction as OpenUrlAction).url).toEqual(
+                'https://kwijibo.com',
+            )
+        })
+
+        it('creates correct elements when url not provided', () => {
+            const result = createTextButton({
+                text: 'Go back',
+                color: 'warning',
+                id: 'Actions.GoHome',
+            })
+
+            // We get the textblock like this rather than by id, because fixing the id
+            // would be bad as a card could use this method a number of times, and end up with
+            // a number of items all with the same id.
+            const text = (result as Container).getItemAt(0) as TextBlock
+
+            // Text checks
+            expect(text.text).toEqual('Go back')
+            expect(text.color).toEqual('warning')
+
+            // Action checks
+            expect(((result as Container).selectAction as SubmitAction).id).toEqual(
+                'Actions.GoHome',
+            )
+        })
+    })
+})

--- a/packages/ui-extensions-core/src/ui-helpers/button-helpers.test.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/button-helpers.test.ts
@@ -1,6 +1,6 @@
 import { createTextButton } from './button-helpers'
 
-import type { Container, OpenUrlAction, SubmitAction, TextBlock } from '../doist-card'
+import type { OpenUrlAction, SubmitAction, TextBlock } from '../doist-card'
 
 describe('button-helpers', () => {
     describe('createTextButton', () => {
@@ -14,16 +14,14 @@ describe('button-helpers', () => {
             // We get the textblock like this rather than by id, because fixing the id
             // would be bad as a card could use this method a number of times, and end up with
             // a number of items all with the same id.
-            const text = (result as Container).getItemAt(0) as TextBlock
+            const text = result.getItemAt(0) as TextBlock
 
             // Text checks
             expect(text.text).toEqual('Go back')
             expect(text.color).toEqual('warning')
 
             // Action checks
-            expect(((result as Container).selectAction as OpenUrlAction).url).toEqual(
-                'https://kwijibo.com',
-            )
+            expect((result.selectAction as OpenUrlAction).url).toEqual('https://kwijibo.com')
         })
 
         it('creates correct elements when url not provided', () => {
@@ -36,16 +34,14 @@ describe('button-helpers', () => {
             // We get the textblock like this rather than by id, because fixing the id
             // would be bad as a card could use this method a number of times, and end up with
             // a number of items all with the same id.
-            const text = (result as Container).getItemAt(0) as TextBlock
+            const text = result.getItemAt(0) as TextBlock
 
             // Text checks
             expect(text.text).toEqual('Go back')
             expect(text.color).toEqual('warning')
 
             // Action checks
-            expect(((result as Container).selectAction as SubmitAction).id).toEqual(
-                'Actions.GoHome',
-            )
+            expect((result.selectAction as SubmitAction).id).toEqual('Actions.GoHome')
         })
     })
 })

--- a/packages/ui-extensions-core/src/ui-helpers/button-helpers.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/button-helpers.ts
@@ -1,4 +1,4 @@
-import { CardElement, Column, ColumnSet, Container, Image, TextBlock } from '../doist-card'
+import { Column, ColumnSet, Container, Image, TextBlock } from '../doist-card'
 import { Action, OpenUrlAction, SubmitAction } from '../doist-card/actions'
 
 import { ICON_SIZE } from './ui-constants'
@@ -10,14 +10,21 @@ import type {
     VerticalAlignment,
 } from '../doist-card/types'
 
-export function createIconButton(options: {
+type CreateIconButtonOptions = {
     action: Action
     buttonText: string
     iconUrl: string
     textColor?: TextColor
     isSubtle?: boolean
     iconSize?: number
-}): CardElement {
+}
+
+/**
+ * Creates a button with a title and an optional icon.
+ * @param {CreateIconButtonOptions} options - The options with which the button will be created.
+ * @return {ColumnSet} A ColumnSet that can be added to a card.
+ */
+export function createIconButton(options: CreateIconButtonOptions): ColumnSet {
     const {
         action,
         buttonText,
@@ -60,7 +67,7 @@ export function createIconButton(options: {
     })
 }
 
-export function createTextButton(options: {
+type CreateTextButtonOptions = {
     text: string
     id?: string
     data?: () => Record<string, unknown> | undefined
@@ -70,7 +77,14 @@ export function createTextButton(options: {
     horizontalAlignment?: HorizontalAlignment
     verticalAlignment?: VerticalAlignment
     textSize?: FontSize
-}): CardElement {
+}
+
+/**
+ * Creates a button that is purely text and will display as just text.
+ * @param {CreateTextButtonOptions} options - The options with which the button will be created.
+ * @return {Container} A Container that can be added to a card.
+ */
+export function createTextButton(options: CreateTextButtonOptions): Container {
     const {
         text,
         id,

--- a/packages/ui-extensions-core/src/ui-helpers/button-helpers.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/button-helpers.ts
@@ -1,0 +1,110 @@
+import { CardElement, Column, ColumnSet, Container, Image, TextBlock } from '../doist-card'
+import { Action, OpenUrlAction, SubmitAction } from '../doist-card/actions'
+
+import { ICON_SIZE } from './ui-constants'
+
+import type {
+    FontSize,
+    HorizontalAlignment,
+    TextColor,
+    VerticalAlignment,
+} from '../doist-card/types'
+
+export function createIconButton(options: {
+    action: Action
+    buttonText: string
+    iconUrl: string
+    textColor?: TextColor
+    isSubtle?: boolean
+    iconSize?: number
+}): CardElement {
+    const {
+        action,
+        buttonText,
+        iconUrl,
+        textColor = 'default',
+        isSubtle = true,
+        iconSize = ICON_SIZE,
+    } = options
+
+    return ColumnSet.fromWithColumns({
+        selectAction: action,
+        columns: [
+            // iconColumn
+            Column.fromWithItems({
+                width: 'auto',
+                spacing: 'none',
+                items: [
+                    Image.from({
+                        url: iconUrl,
+                        altText: buttonText,
+                        pixelHeight: iconSize,
+                        pixelWidth: iconSize,
+                    }),
+                ],
+            }),
+            // textColumn
+            Column.fromWithItems({
+                width: 'auto',
+                spacing: 'small',
+                verticalContentAlignment: 'center',
+                items: [
+                    TextBlock.from({
+                        text: buttonText,
+                        isSubtle: isSubtle && textColor !== 'accent',
+                        color: textColor,
+                    }),
+                ],
+            }),
+        ],
+    })
+}
+
+export function createTextButton(options: {
+    text: string
+    id?: string
+    data?: () => Record<string, unknown> | undefined
+    isSubtle?: boolean
+    color?: TextColor
+    url?: string
+    horizontalAlignment?: HorizontalAlignment
+    verticalAlignment?: VerticalAlignment
+    textSize?: FontSize
+}): CardElement {
+    const {
+        text,
+        id,
+        data,
+        isSubtle = false,
+        color,
+        url,
+        horizontalAlignment,
+        verticalAlignment,
+        textSize,
+    } = options
+
+    const textBlock = TextBlock.from({
+        isSubtle,
+        color: color ?? 'default',
+        size: textSize ?? 'default',
+        text,
+        horizontalAlignment,
+    })
+
+    const button = url
+        ? OpenUrlAction.from({
+              url,
+              title: text,
+          })
+        : SubmitAction.from({
+              id: id,
+              associatedInputs: 'none',
+              data: data?.(),
+          })
+
+    return Container.fromWithItems({
+        selectAction: button,
+        verticalContentAlignment: verticalAlignment ?? 'center',
+        items: [textBlock],
+    })
+}

--- a/packages/ui-extensions-core/src/ui-helpers/card-helpers.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/card-helpers.ts
@@ -1,0 +1,5 @@
+import { type DoistCardVersion, DoistCard } from '../doist-card'
+
+export function createEmptyCard(doistCardVersion?: DoistCardVersion): DoistCard {
+    return DoistCard.from({ doistCardVersion: doistCardVersion || '0.5' })
+}

--- a/packages/ui-extensions-core/src/ui-helpers/card-helpers.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/card-helpers.ts
@@ -1,5 +1,8 @@
 import { type DoistCardVersion, DoistCard } from '../doist-card'
 
+/**
+ * Creates an empty DoistCard
+ */
 export function createEmptyCard(doistCardVersion?: DoistCardVersion): DoistCard {
     return DoistCard.from({ doistCardVersion: doistCardVersion || '0.5' })
 }

--- a/packages/ui-extensions-core/src/ui-helpers/headers.test.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/headers.test.ts
@@ -1,0 +1,34 @@
+import { createLogoWithTextHeader } from './headers'
+import { HEADER_COLUMN_ID, HEADER_IMAGE_ID, HEADER_TITLE_ID } from './ui-constants'
+
+import type { ColumnSet, SubmitAction } from '../doist-card'
+import type { Image, TextBlock } from '../doist-card/card-elements'
+
+describe('headers', () => {
+    test('createLogoHeader creates the header items correctly', () => {
+        const result = createLogoWithTextHeader({
+            logoUrl: 'https://doist.com/images/kwijibo.png',
+            headerText: 'Login to Kwijibo',
+        })
+
+        const headerImage = result.getElementById(HEADER_IMAGE_ID) as Image
+        const headerTitle = result.getElementById(HEADER_TITLE_ID) as TextBlock
+        const headerColumns = result.getElementById(HEADER_COLUMN_ID) as ColumnSet
+
+        // Image checks
+        expect(headerImage.pixelHeight).toEqual(24)
+        expect(headerImage.url).toEqual('https://doist.com/images/kwijibo.png')
+
+        // Title checks
+        expect(headerTitle.text).toEqual('Login to Kwijibo')
+        expect(headerTitle.size).toEqual('default')
+        expect(headerTitle.weight).toEqual('bolder')
+
+        // ColumnSet checks
+        expect(headerColumns.selectAction).not.toBeUndefined()
+
+        // Action checks
+        expect((headerColumns.selectAction as SubmitAction).associatedInputs).toEqual('none')
+        expect((headerColumns.selectAction as SubmitAction).id).toEqual('Action.GoHome')
+    })
+})

--- a/packages/ui-extensions-core/src/ui-helpers/headers.test.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/headers.test.ts
@@ -1,4 +1,4 @@
-import { createLogoWithTextHeader } from './headers'
+import { createLogoWithText } from './headers'
 import { HEADER_COLUMN_ID, HEADER_IMAGE_ID, HEADER_TITLE_ID } from './ui-constants'
 
 import type { ColumnSet, SubmitAction } from '../doist-card'
@@ -6,7 +6,7 @@ import type { Image, TextBlock } from '../doist-card/card-elements'
 
 describe('headers', () => {
     test('createLogoHeader creates the header items correctly', () => {
-        const result = createLogoWithTextHeader({
+        const result = createLogoWithText({
             logoUrl: 'https://doist.com/images/kwijibo.png',
             headerText: 'Login to Kwijibo',
         })

--- a/packages/ui-extensions-core/src/ui-helpers/headers.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/headers.ts
@@ -25,8 +25,9 @@ type HeaderOptions = {
     middleColumnItems: CardElement[]
     /**
      * The empty space image is required to actually render the empty space.
+     * If not set, no empty spaces will be included
      */
-    emptySpaceImageUrl: string
+    emptySpaceImageUrl?: string
 }
 
 /**

--- a/packages/ui-extensions-core/src/ui-helpers/headers.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/headers.ts
@@ -10,22 +10,6 @@ import {
 
 import { HEADER_COLUMN_ID, HEADER_IMAGE_ID, HEADER_TITLE_ID, ICON_SIZE } from './ui-constants'
 
-type EmptySpace =
-    | {
-          /**
-           * When true, it includes an empty space to ensure the items in the middle are centered.
-           */
-          includeEmptySpacing: true
-          /**
-           * The empty space image is required to actually render the empty space.
-           */
-          emptySpaceImageUrl: string
-      }
-    | {
-          includeEmptySpacing: false
-          emptySpaceImageUrl?: never
-      }
-
 type HeaderOptions = {
     /**
      * Items for the left column
@@ -39,22 +23,20 @@ type HeaderOptions = {
      * Items for the middle column
      */
     middleColumnItems: CardElement[]
-} & EmptySpace
+    /**
+     * The empty space image is required to actually render the empty space.
+     */
+    emptySpaceImageUrl: string
+}
 
 /**
  * This helper function will allow you to create a three-column header.
  * @summary If the description is long, write your summary here. Otherwise, feel free to remove this.
  * @param {HeaderOptions} options - The options for the header.
- * @return {CardElement} A Doist Card element that can be added to a card.
+ * @return {ColumnSet} A ColumnSet element that can be added to a card.
  */
-export function createHeader(options: HeaderOptions): CardElement {
-    const {
-        leftColumnItems,
-        rightColumnItems,
-        middleColumnItems,
-        includeEmptySpacing = true,
-        emptySpaceImageUrl,
-    } = options
+export function createHeader(options: HeaderOptions): ColumnSet {
+    const { leftColumnItems, rightColumnItems, middleColumnItems, emptySpaceImageUrl } = options
 
     function createEmptyImage() {
         return Image.from({
@@ -74,19 +56,19 @@ export function createHeader(options: HeaderOptions): CardElement {
 
     if (leftColumnItems.length > 0) {
         leftColumnItems.forEach((x) => leftColumn.addItem(x))
-    } else if (includeEmptySpacing) {
+    } else if (emptySpaceImageUrl) {
         leftColumn.addItem(createEmptyImage())
     }
 
     if (middleColumnItems.length > 0) {
         middleColumnItems.forEach((x) => middleColumn.addItem(x))
-    } else if (includeEmptySpacing) {
+    } else if (emptySpaceImageUrl) {
         middleColumn.addItem(createEmptyImage())
     }
 
     if (rightColumnItems.length > 0) {
         rightColumnItems.forEach((x) => rightColumn.addItem(x))
-    } else if (includeEmptySpacing) {
+    } else if (emptySpaceImageUrl) {
         rightColumn.addItem(createEmptyImage())
     }
 

--- a/packages/ui-extensions-core/src/ui-helpers/headers.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/headers.ts
@@ -1,0 +1,127 @@
+import {
+    CardElement,
+    Column,
+    ColumnSet,
+    HorizontalAlignment,
+    Image,
+    SubmitAction,
+    TextBlock,
+} from '../doist-card'
+
+import { HEADER_COLUMN_ID, HEADER_IMAGE_ID, HEADER_TITLE_ID, ICON_SIZE } from './ui-constants'
+
+export function createHeader(options: {
+    leftColumnItems: CardElement[]
+    rightColumnItems: CardElement[]
+    middleColumnItems: CardElement[]
+    includeEmptySpacing?: boolean
+    emptySpaceImageUrl?: string
+}): CardElement {
+    const {
+        leftColumnItems,
+        rightColumnItems,
+        middleColumnItems,
+        includeEmptySpacing = true,
+        emptySpaceImageUrl,
+    } = options
+
+    function createEmptyImage() {
+        return Image.from({
+            url: emptySpaceImageUrl,
+            pixelHeight: ICON_SIZE,
+            pixelWidth: ICON_SIZE,
+        })
+    }
+
+    const leftColumn = new Column('auto')
+    leftColumn.verticalContentAlignment = 'center'
+
+    const middleColumn = new Column('stretch')
+    middleColumn.verticalContentAlignment = 'center'
+
+    const rightColumn = new Column('auto')
+
+    if (leftColumnItems.length > 0) {
+        leftColumnItems.forEach((x) => leftColumn.addItem(x))
+    } else if (includeEmptySpacing && Boolean(emptySpaceImageUrl)) {
+        leftColumn.addItem(createEmptyImage())
+    }
+
+    if (middleColumnItems.length > 0) {
+        middleColumnItems.forEach((x) => middleColumn.addItem(x))
+    } else if (includeEmptySpacing && Boolean(emptySpaceImageUrl)) {
+        middleColumn.addItem(createEmptyImage())
+    }
+
+    if (rightColumnItems.length > 0) {
+        rightColumnItems.forEach((x) => rightColumn.addItem(x))
+    } else if (includeEmptySpacing && Boolean(emptySpaceImageUrl)) {
+        rightColumn.addItem(createEmptyImage())
+    }
+
+    const header = ColumnSet.from({ spacing: 'medium' })
+    header.spacing = 'medium'
+    if (leftColumn.getItemCount() > 0) {
+        header.addColumn(leftColumn)
+    }
+    if (middleColumn.getItemCount() > 0) {
+        header.addColumn(middleColumn)
+    }
+    if (rightColumn.getItemCount() > 0) {
+        header.addColumn(rightColumn)
+    }
+
+    return header
+}
+
+export function createLogoWithTextHeader(options: {
+    logoUrl: string
+    headerText: string
+    horizontalAlignment?: HorizontalAlignment
+    headerButtonId?: string
+}): CardElement {
+    const {
+        headerText,
+        logoUrl,
+        horizontalAlignment = 'center',
+        headerButtonId = 'Action.GoHome',
+    } = options
+
+    return ColumnSet.fromWithColumns({
+        id: HEADER_COLUMN_ID,
+        horizontalAlignment,
+        spacing: 'medium',
+        selectAction: SubmitAction.from({
+            id: headerButtonId,
+            associatedInputs: 'none',
+        }),
+        columns: [
+            // logoColumn
+            Column.fromWithItems({
+                width: 'auto',
+                items: [
+                    Image.from({
+                        id: HEADER_IMAGE_ID,
+                        url: logoUrl,
+                        pixelHeight: ICON_SIZE,
+                        aspectRatio: 1,
+                    }),
+                ],
+            }),
+            // titleColumn
+            Column.fromWithItems({
+                width: 'auto',
+                verticalContentAlignment: 'center',
+                items: [
+                    TextBlock.from({
+                        id: HEADER_TITLE_ID,
+                        size: 'default',
+                        weight: 'bolder',
+                        horizontalAlignment,
+                        text: headerText,
+                    }),
+                ],
+            }),
+        ],
+    })
+}

--- a/packages/ui-extensions-core/src/ui-helpers/headers.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/headers.ts
@@ -10,13 +10,44 @@ import {
 
 import { HEADER_COLUMN_ID, HEADER_IMAGE_ID, HEADER_TITLE_ID, ICON_SIZE } from './ui-constants'
 
-export function createHeader(options: {
+type EmptySpace =
+    | {
+          /**
+           * When true, it includes an empty space to ensure the items in the middle are centered.
+           */
+          includeEmptySpacing: true
+          /**
+           * The empty space image is required to actually render the empty space.
+           */
+          emptySpaceImageUrl: string
+      }
+    | {
+          includeEmptySpacing: false
+          emptySpaceImageUrl?: never
+      }
+
+type HeaderOptions = {
+    /**
+     * Items for the left column
+     */
     leftColumnItems: CardElement[]
+    /**
+     * Items for the right column
+     */
     rightColumnItems: CardElement[]
+    /**
+     * Items for the middle column
+     */
     middleColumnItems: CardElement[]
-    includeEmptySpacing?: boolean
-    emptySpaceImageUrl?: string
-}): CardElement {
+} & EmptySpace
+
+/**
+ * This helper function will allow you to create a three-column header.
+ * @summary If the description is long, write your summary here. Otherwise, feel free to remove this.
+ * @param {HeaderOptions} options - The options for the header.
+ * @return {CardElement} A Doist Card element that can be added to a card.
+ */
+export function createHeader(options: HeaderOptions): CardElement {
     const {
         leftColumnItems,
         rightColumnItems,
@@ -43,19 +74,19 @@ export function createHeader(options: {
 
     if (leftColumnItems.length > 0) {
         leftColumnItems.forEach((x) => leftColumn.addItem(x))
-    } else if (includeEmptySpacing && Boolean(emptySpaceImageUrl)) {
+    } else if (includeEmptySpacing) {
         leftColumn.addItem(createEmptyImage())
     }
 
     if (middleColumnItems.length > 0) {
         middleColumnItems.forEach((x) => middleColumn.addItem(x))
-    } else if (includeEmptySpacing && Boolean(emptySpaceImageUrl)) {
+    } else if (includeEmptySpacing) {
         middleColumn.addItem(createEmptyImage())
     }
 
     if (rightColumnItems.length > 0) {
         rightColumnItems.forEach((x) => rightColumn.addItem(x))
-    } else if (includeEmptySpacing && Boolean(emptySpaceImageUrl)) {
+    } else if (includeEmptySpacing) {
         rightColumn.addItem(createEmptyImage())
     }
 
@@ -74,17 +105,32 @@ export function createHeader(options: {
     return header
 }
 
-export function createLogoWithTextHeader(options: {
+type LogoWithTextOptions = {
     logoUrl: string
     headerText: string
     horizontalAlignment?: HorizontalAlignment
+    /**
+     * The ID for the card element's SelectAction.
+     */
     headerButtonId?: string
-}): CardElement {
+    /**
+     * The data for the card element's SelectAction.
+     */
+    headerButtonData?: () => Record<string, unknown>
+}
+
+/**
+ * @summary The creates a clickable card element with an image and text side-by-side
+ * @param {LogoWithTextOptions} options - The options for creating this item.
+ * @return {CardElement} A Doist Card element that can be added to a card.
+ */
+export function createLogoWithText(options: LogoWithTextOptions): CardElement {
     const {
         headerText,
         logoUrl,
         horizontalAlignment = 'center',
         headerButtonId = 'Action.GoHome',
+        headerButtonData,
     } = options
 
     return ColumnSet.fromWithColumns({
@@ -94,6 +140,7 @@ export function createLogoWithTextHeader(options: {
         selectAction: SubmitAction.from({
             id: headerButtonId,
             associatedInputs: 'none',
+            data: headerButtonData ? headerButtonData() : undefined,
         }),
         columns: [
             // logoColumn

--- a/packages/ui-extensions-core/src/ui-helpers/index.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/index.ts
@@ -1,2 +1,4 @@
 export * from './button-helpers'
 export * from './card-helpers'
+export * from './headers'
+export * from './ui-constants'

--- a/packages/ui-extensions-core/src/ui-helpers/index.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './button-helpers'
+export * from './card-helpers'

--- a/packages/ui-extensions-core/src/ui-helpers/ui-constants.ts
+++ b/packages/ui-extensions-core/src/ui-helpers/ui-constants.ts
@@ -1,0 +1,5 @@
+export const ICON_SIZE = 24
+
+export const HEADER_IMAGE_ID = 'HeaderImage'
+export const HEADER_TITLE_ID = 'HeaderTitle'
+export const HEADER_COLUMN_ID = 'HeaderColumn'

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "7.0.0-alpha.0",
+    "version": "7.0.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -36,7 +36,7 @@
     },
     "peerDependencies": {
         "@doist/reactist": "^15.0.0",
-        "@doist/ui-extensions-core": "^4.0.0-alpha.1",
+        "@doist/ui-extensions-core": "^4.0.0",
         "adaptivecards": "^2.9.0",
         "react": ">=17"
     },

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "6.1.0",
+    "version": "7.0.0-alpha.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -36,7 +36,7 @@
     },
     "peerDependencies": {
         "@doist/reactist": "^15.0.0",
-        "@doist/ui-extensions-core": "^3.2.1",
+        "@doist/ui-extensions-core": "^4.0.0-alpha.0",
         "adaptivecards": "^2.9.0",
         "react": ">=17"
     },

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "7.0.0",
+    "version": "7.0.0-alpha.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -36,7 +36,7 @@
     },
     "peerDependencies": {
         "@doist/reactist": "^15.0.0",
-        "@doist/ui-extensions-core": "^4.0.0",
+        "@doist/ui-extensions-core": "^4.0.0-alpha.1",
         "adaptivecards": "^2.9.0",
         "react": ">=17"
     },

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "7.0.0-alpha.0",
+    "version": "7.0.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -36,7 +36,7 @@
     },
     "peerDependencies": {
         "@doist/reactist": "^15.0.0",
-        "@doist/ui-extensions-core": "^4.0.0-alpha.0",
+        "@doist/ui-extensions-core": "^4.0.0",
         "adaptivecards": "^2.9.0",
         "react": ">=17"
     },

--- a/packages/ui-extensions-react/src/actions/submitAction.ts
+++ b/packages/ui-extensions-react/src/actions/submitAction.ts
@@ -9,6 +9,7 @@ import {
     PropertyBag,
     PropertyDefinition,
     SerializableObject,
+    StringProperty,
     SubmitAction,
     Versions,
 } from 'adaptivecards'
@@ -44,8 +45,13 @@ export class SubmitActionist extends SubmitAction {
         },
     )
 
+    static readonly loadingTextProperty = new StringProperty(Versions.v1_3, 'loadingText')
+
     @property(SubmitActionist.associatedInputProperty)
     associatedInput?: AssociatedInputs
+
+    @property(SubmitActionist.loadingTextProperty)
+    loadingText?: string
 
     /**
      * This method is copied from the adaptivecards SDK verbatim with the exception

--- a/packages/ui-extensions-react/src/components/AdaptiveCardRenderer.css
+++ b/packages/ui-extensions-react/src/components/AdaptiveCardRenderer.css
@@ -5,6 +5,7 @@
 .adaptive-card-loading-container {
     white-space: normal;
     display: flex;
+    flex-direction: column;
     height: 100%;
     width: 100%;
     background: var(--doist-card-loading-background);

--- a/packages/ui-extensions-react/src/hooks/useAdaptiveCardsConnection.test.ts
+++ b/packages/ui-extensions-react/src/hooks/useAdaptiveCardsConnection.test.ts
@@ -151,7 +151,8 @@ describe('useAdaptiveCardsConnection tests', () => {
 
             let actual: string | undefined = undefined
             await renderHookAsync(2, DEFAULT_CONTEXT_V2, {
-                'composer.append': (x) => (actual = x.text),
+                'composer.append': (x) =>
+                    x.bridgeActionType === 'composer.append' ? (actual = x.text) : undefined,
             })
 
             expect(actual).toBe(expected)

--- a/packages/ui-extensions-react/src/hooks/useAdaptiveCardsConnection.ts
+++ b/packages/ui-extensions-react/src/hooks/useAdaptiveCardsConnection.ts
@@ -46,8 +46,8 @@ export function useAdaptiveCardsConnection({
 }: DoistCardConnectionParams): DoistCardsConnection {
     const [result, setResult] = React.useState<DoistCardResult>({ type: 'loading' })
 
-    function setLoading() {
-        setResult({ type: 'loading' })
+    function setLoading(loadingText?: string) {
+        setResult({ type: 'loading', loadingText })
     }
 
     function setCardData(card: ExtensionCard) {
@@ -59,8 +59,8 @@ export function useAdaptiveCardsConnection({
     }
 
     const onAction = React.useCallback(
-        async (action: DoistCardAction) => {
-            setLoading()
+        async (action: DoistCardAction, loadingText?: string) => {
+            setLoading(loadingText)
             const request = createRequest(
                 version,
                 context,

--- a/packages/ui-extensions-react/src/stories/StorybookConnectedCard.tsx
+++ b/packages/ui-extensions-react/src/stories/StorybookConnectedCard.tsx
@@ -3,8 +3,8 @@ import React, { useEffect, useState } from 'react'
 import { AdaptiveCardRenderer } from '../components'
 import { DoistCardConnectionParams, useAdaptiveCardsConnection } from '../hooks'
 
-import type { DoistCardBridge, DoistCardContext } from '@doist/ui-extensions-core'
-import type { ExtensionError } from '../types'
+import type { DoistCardContext } from '@doist/ui-extensions-core'
+import type { DoistCardBridge, ExtensionError } from '../types'
 
 export type StorybookConnectedCardProps = {
     endpointUrl: string
@@ -48,9 +48,7 @@ export function StorybookConnectedCard(props: StorybookConnectedCardProps): JSX.
             {props.children?.(configuration, setConfiguration)}
             <ul>
                 {bridgeActions.map((x, i) => (
-                    <li key={x.text ?? `${x.bridgeActionType}-${i}`}>{`type: ${
-                        x.bridgeActionType
-                    }; text: ${x.text ?? ''}`}</li>
+                    <li key={`${x.bridgeActionType}-${i}`}>{`type: ${x.bridgeActionType};`}</li>
                 ))}
             </ul>
         </div>

--- a/packages/ui-extensions-react/src/types/types.ts
+++ b/packages/ui-extensions-react/src/types/types.ts
@@ -2,7 +2,6 @@ import type {
     DoistCard,
     DoistCardAction,
     DoistCardBridge as OriginalDoistCardBridge,
-    DoistCardBridgeActionType,
     DoistCardContext,
     DoistCardError,
     DoistCardRequest,
@@ -26,14 +25,17 @@ export type DoistCardsConnection = {
 }
 
 export type DoistCardResult =
-    | { type: 'loading' }
+    | { type: 'loading'; loadingText?: string }
     | { type: 'loaded'; card: ExtensionCard }
     | { type: 'error'; error: ExtensionError }
 
-type AllBridgeActionTypes = DoistCardBridgeActionType | 'consent.required'
-export type DoistCardBridge = OriginalDoistCardBridge & {
-    scopes?: string
+export type ConsentRequiredBridge = {
+    bridgeActionType: 'consent.required'
+    scopes: string
 }
+
+type AllBridgeActionTypes = DoistCardBridge['bridgeActionType']
+export type DoistCardBridge = OriginalDoistCardBridge | ConsentRequiredBridge
 
 export type BridgeActionCallbacks = Partial<
     Record<AllBridgeActionTypes, (action: DoistCardBridge) => unknown>


### PR DESCRIPTION
This release does a few things, namely:

# Core

- Adds `loadingText` property to `SubmitAction`. This will allow extension developers to display some text while the new card is being fetch. Demo: https://share.getcloudapp.com/Kou1bwzX
- Adds `fromWithItems()` to DoistCard, this API is the same as what we have on Container-based objects.
- Improves the types for DoistCardBridge. I have now separated them all into their own type and create a discriminated union type, this will stop people from including `text` when sending a bridge notification, for example.
- Added `request.sync` Bridge. This is for Todoist and will trigger a sync when used. See discussion: https://twist.com/a/1585/ch/190200/t/3851022/
- Added `additionalUserContext` to the Todoist context, this will allow us to let extension developers know if the user is a pro subscriber. See discussion: https://twist.com/a/1585/ch/590477/t/3852095/
- Split out separated types for `ContextMenuData` so there are Todoist and Twist variants, but can be used as a whole type.
- I've also separated the Twist/Todoist types into a separate file so it's easier to manage.
- Brought over a couple of UI helper functions from `@doist/ui-extensions-server`. These are unopinionated about server type, but they allow you to create UIs how we do in our extensions. This means they have been slightly refactored to not require the UIBuilderContext. Specifically:
   - `createIconButton()`
   - `createEmptyCard()`
   - `createHeader()`
   - `createLogoWithTextHeader()` (was `createLogoHeader()`)

# React

- Adds the `loadingText` property to `SubmitActionist`, this is to aid the consumption of the json in our web apps and is required when adding a new schema field.
- Implements the loadingText to be used in the `AdaptiveCardRenderer` and `useAdaptiveCardsConnection`.
- Updates Bridge types to use individual bridge type (for the `consent.required` bridge).

# Testing

I have pushed each of these packages to GH packages under an alpha tag. Because of the changes in these packages, I have upped the major version as the DoistCardBridge changes made this a breaking change. 

Because they are pushed as alpha packages, they can be easily tested in the consuming products (todoist-web/event-integrations) without having to do some convoluted linking. For testing the `loadingText` changes and implementations, you'll need to be using both the following:

- event-integrations: `scottl/update-ui-extensions` branch. 
- todoist-web: `scottl/ui-extensions-updates` branch.

I will raise separate PRs for them shortly once this one has been merged so that I don't have to raise the PRs with the alpha versions still being used.