### PR TITLE
feat: Adds a data generic type for DoistCardRequest.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28801,7 +28801,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "4.0.0",
+            "version": "4.1.0",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/src/types/data-exchange.ts
+++ b/packages/ui-extensions-core/src/types/data-exchange.ts
@@ -89,9 +89,9 @@ export type DoistCardContext = {
 /**
  * A top-level object representing a request the integration client does against the integration server.
  */
-export type DoistCardRequest = {
+export type DoistCardRequest<Action extends Partial<DoistCardAction> = DoistCardAction> = {
     context: DoistCardContext
-    action: DoistCardAction
+    action: Action
     extensionType: DoistCardExtensionType
     /**
      * This is the maximum version of Doist Card that the requesting client supports. This can be used


### PR DESCRIPTION
This allows us to do something like the following and have it correctly typed: 

```typescript
type Thing = {
   projectId: string
}

function something(request: DoistCardRequest<{ data: Thing}>) {
  const projectId = request.action.data?.projectId
}
```