### PR TITLE
feat: Adds `fromWithInlines` for RichTextBlock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28801,7 +28801,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "4.1.0",
+            "version": "4.1.1",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/src/doist-card/card-elements.ts
+++ b/packages/ui-extensions-core/src/doist-card/card-elements.ts
@@ -259,4 +259,17 @@ export class RichTextBlock extends CardElement {
     protected getJsonTypeName(): string {
         return 'RichTextBlock'
     }
+
+    static fromWithInlines<T extends RichTextBlock>(
+        this: new () => T,
+        props: Props<T> & { inlines?: Inline[] },
+    ): T {
+        const o = new this()
+        const { inlines, ...rest } = props
+        Object.assign(o, rest)
+        if (inlines && inlines.length > 0) {
+            inlines.forEach((inline) => o.addInline(inline))
+        }
+        return o
+    }
 }


### PR DESCRIPTION
Matches the rest of the items that have internal items.