### PR TITLE
chore: Updates user context id to support string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29298,7 +29298,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "4.1.1",
+            "version": "4.1.2",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "4.1.1",
+    "version": "4.1.2",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/src/types/data-exchange.ts
+++ b/packages/ui-extensions-core/src/types/data-exchange.ts
@@ -67,7 +67,7 @@ export type DoistCardAction = {
 export type DoistCardContextUser = {
     short_name: string
     timezone: string
-    id: number
+    id: number | string
     lang: string
     first_name: string
     name: string


### PR DESCRIPTION
In line with Todoist API sending ids back as strings, the context for a user in UI extensions should also support being sent as a string.

This needs to be a `number | string` type because this package is still used in Twist where those IDs are still numbers.