### PR TITLE
chore: Removes DeprecatedButton usage.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27228,7 +27228,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "9.1.0",
+            "version": "9.2.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "9.1.0",
+    "version": "9.2.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",

--- a/packages/ui-extensions-react/src/renderers/action-renderers.tsx
+++ b/packages/ui-extensions-react/src/renderers/action-renderers.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from 'react-dom'
 
-import { Button, ButtonProps, DeprecatedButton } from '@doist/reactist'
+import { Button, ButtonProps } from '@doist/reactist'
 
 import { ActionAlignment, ActionStyle, GlobalRegistry, OpenUrlAction } from 'adaptivecards'
 import classNames from 'classnames'
@@ -8,15 +8,12 @@ import classNames from 'classnames'
 import { ClipboardAction, SubmitActionist } from '../actions'
 import { isDangerButton, isPrimaryButton } from '../utils'
 
-import type { CSSProperties } from 'react'
-
 type ActionProps = {
     title: string
     style: ActionStyle
     baseCssClass?: string
     id?: string
     onClick?: ((event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void) | undefined
-    isLink?: boolean
     actionAlignment: ActionAlignment
     isInputButton?: boolean
 }
@@ -34,7 +31,6 @@ export function createActionDiv({
     baseCssClass,
     id,
     onClick,
-    isLink,
     actionAlignment,
     isInputButton,
 }: ActionProps): HTMLDivElement {
@@ -43,36 +39,18 @@ export function createActionDiv({
         div.style.paddingLeft = '6px'
     }
 
-    const linkStyle: CSSProperties = {
-        marginTop: '6px',
-    }
-
     // eslint-disable-next-line import/no-named-as-default-member
     ReactDOM.render(
-        isLink ? (
-            <DeprecatedButton
-                id={id}
-                onClick={onClick}
-                className={classNames(baseCssClass, {
-                    'ac-action-stretch': actionAlignment === ActionAlignment.Stretch,
-                })}
-                variant="link"
-                style={linkStyle}
-            >
-                {title}
-            </DeprecatedButton>
-        ) : (
-            <Button
-                {...getNewButtonProps(style)}
-                id={id}
-                onClick={onClick}
-                exceptionallySetClassName={classNames(baseCssClass, {
-                    'ac-action-stretch': actionAlignment === ActionAlignment.Stretch,
-                })}
-            >
-                {title}
-            </Button>
-        ),
+        <Button
+            {...getNewButtonProps(style)}
+            id={id}
+            onClick={onClick}
+            exceptionallySetClassName={classNames(baseCssClass, {
+                'ac-action-stretch': actionAlignment === ActionAlignment.Stretch,
+            })}
+        >
+            {title}
+        </Button>,
         div,
     )
     return div


### PR DESCRIPTION
Action rendering was still using `DeprecatedButton` from Reactist, but we should really be moving to the main `Button` component. This PR addresses that.