### PR TITLE
chore: Restore `orientation` property

### DIFF
--- a/packages/ui-extensions-core/src/doist-card/containers.ts
+++ b/packages/ui-extensions-core/src/doist-card/containers.ts
@@ -10,6 +10,7 @@ import type {
     ContainerStyle,
     HorizontalAlignment,
     ImageFillMode,
+    Orientation,
     VerticalAlignment,
 } from './types'
 
@@ -240,6 +241,12 @@ export class Container extends ContainerWithNoItems {
 export class ActionSet extends CardElement {
     @JsonProperty()
     private actions: Action[] = []
+
+    /**
+     * Sets the orientation of the actions.
+     */
+    @JsonProperty()
+    orientation?: Orientation
 
     /**
      * Adds an {@link Action} to the action set.


### PR DESCRIPTION
## Overview

In this PR, we are adding the `orientation` property back to `ActionSet`. It was accidentally removed in https://github.com/Doist/ui-extensions/pull/42/files#r1073821675. If it was removed on purpose, this PR should be closed.