### PR TITLE
chore: Splits the User context to be Todoist/Twist specific

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27220,7 +27220,7 @@
         },
         "packages/ui-extensions-core": {
             "name": "@doist/ui-extensions-core",
-            "version": "4.1.2",
+            "version": "4.2.0",
             "license": "MIT",
             "dependencies": {
                 "typescript-json-serializer": "^3.4.5"

--- a/packages/ui-extensions-core/package.json
+++ b/packages/ui-extensions-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-core",
-    "version": "4.1.2",
+    "version": "4.2.0",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/ui-extensions-core/src/types/data-exchange.ts
+++ b/packages/ui-extensions-core/src/types/data-exchange.ts
@@ -1,7 +1,7 @@
 import type { DoistCard } from '../doist-card'
 import type { DoistCardBridge } from './bridges'
-import type { TodoistContext, TodoistContextMenuData } from './todoist'
-import type { TwistContext, TwistContextMenuData } from './twist'
+import type { TodoistContext, TodoistContextMenuData, TodoistContextUser } from './todoist'
+import type { TwistContext, TwistContextMenuData, TwistContextUser } from './twist'
 
 /**
  * The types of actions that an adaptive card integration can request.
@@ -64,15 +64,7 @@ export type DoistCardAction = {
 /**
  * The current user that invoked the integration.
  */
-export type DoistCardContextUser = {
-    short_name: string
-    timezone: string
-    id: number | string
-    lang: string
-    first_name: string
-    name: string
-    email: string
-}
+export type DoistCardContextUser = TodoistContextUser | TwistContextUser
 
 export type Theme = 'light' | 'dark'
 

--- a/packages/ui-extensions-core/src/types/doist.ts
+++ b/packages/ui-extensions-core/src/types/doist.ts
@@ -1,0 +1,8 @@
+export type DoistContextUser = {
+    short_name: string
+    timezone: string
+    lang: string
+    first_name: string
+    name: string
+    email: string
+}

--- a/packages/ui-extensions-core/src/types/index.ts
+++ b/packages/ui-extensions-core/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './bridges'
 export * from './data-exchange'
+export * from './doist'
 export * from './todoist'
 export * from './twist'

--- a/packages/ui-extensions-core/src/types/todoist.ts
+++ b/packages/ui-extensions-core/src/types/todoist.ts
@@ -1,3 +1,5 @@
+import type { DoistContextUser } from './doist'
+
 type TodoistIdAndName = { id: string; name: string }
 
 /**
@@ -69,3 +71,7 @@ export type TodoistContextMenuData = {
 }
 
 export type TodoistContextMenuSource = 'project' | 'task'
+
+export type TodoistContextUser = DoistContextUser & {
+    id: string
+}

--- a/packages/ui-extensions-core/src/types/twist.ts
+++ b/packages/ui-extensions-core/src/types/twist.ts
@@ -1,3 +1,5 @@
+import type { DoistContextUser } from './doist'
+
 /**
  * Context on which interactions with the adaptive card integration happen.
  */
@@ -91,4 +93,8 @@ export type TwistContextMenuData = {
      * date the thread was created.
      */
     postedDate: Date
+}
+
+export type TwistContextUser = DoistContextUser & {
+    id: number
 }


### PR DESCRIPTION
A previous change to the `user.id` field in the `DoistCardContextUser` resulted in potential confusion on types usage. 

This PR splits that user into a Twist/Todoist variant, with `DoistCardContextUser` accepting either. This means if you have already been using DoistCardContextUser prior to the `number | string` change, you can just choose to use `TwistContextUser` as the type to avoid any type issues.