### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,7 +6,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - uses: actions/setup-node@v3
               with:

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Configure doist package repository
               uses: actions/setup-node@v3

--- a/.github/workflows/core-deploy.yml
+++ b/.github/workflows/core-deploy.yml
@@ -12,7 +12,7 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Git checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Configure Doist package repository
               uses: actions/setup-node@v3
@@ -38,7 +38,7 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Git checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Configure Doist package repository
               uses: actions/setup-node@v3

--- a/.github/workflows/react-ci.yml
+++ b/.github/workflows/react-ci.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Configure doist package repository
               uses: actions/setup-node@v3

--- a/.github/workflows/react-deploy.yml
+++ b/.github/workflows/react-deploy.yml
@@ -12,7 +12,7 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Git checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Configure Doist package repository
               uses: actions/setup-node@v3

--- a/.github/workflows/upload-schema.yml
+++ b/.github/workflows/upload-schema.yml
@@ -22,10 +22,10 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Git checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v1
+              uses: aws-actions/configure-aws-credentials@v4
               with:
                   role-to-assume: arn:aws:iam::011833101604:role/doist-schemas-RoleCI-1P8IZE7IZUTXD
                   role-duration-seconds: 900


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
