### PR TITLE
chore: update Reactist to v21 and bump version to 10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2240,25 +2240,27 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-15.0.0.tgz",
-            "integrity": "sha512-R32CKKeIrsCbOKGyOoBYjhXODyZNfBKnGDIkC65IgDGTmvriVYqKNXJ9uxt2+TgZmzFjFwI55ipsMvnSwnwERg==",
+            "version": "21.3.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-21.3.0.tgz",
+            "integrity": "sha512-dxgeNyhO6x9cbfv/pMhUmCRrTjY9ITpNtGJyG1diX6Ze7fyROuX8/L0f3H5jQtcahZRTXLG99IrPSZN6PamuYg==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
                 "@reach/dialog": "^0.16.0",
                 "aria-hidden": "^1.2.1",
-                "ariakit": "2.0.0-next.27",
-                "ariakit-utils": "0.17.0-next.18",
+                "ariakit": "2.0.0-next.43",
+                "ariakit-react-utils": "0.17.0-next.27",
+                "ariakit-utils": "0.17.0-next.27",
                 "dayjs": "^1.8.10",
                 "patch-package": "^6.4.6",
                 "react-focus-lock": "^2.9.1",
                 "react-keyed-flatten-children": "^1.3.0",
-                "react-markdown": "^5.0.3"
+                "react-markdown": "^5.0.3",
+                "use-callback-ref": "^1.3.0"
             },
             "engines": {
-                "node": "^16.0.0",
-                "npm": "^8.3.0"
+                "node": "^16.0.0 || ^18.0.0",
+                "npm": "^8.3.0 || ^9.0.0"
             },
             "peerDependencies": {
                 "classnames": "^2.2.5",
@@ -2442,19 +2444,29 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.3.tgz",
-            "integrity": "sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==",
-            "dev": true
-        },
-        "node_modules/@floating-ui/dom": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.0.tgz",
-            "integrity": "sha512-PS75dnMg4GdWjDFOiOs15cDzYJpukRNHqQn0ugrBlsrpk2n+y8bwZ24XrsdLSL7kxshmxxr2nTNycLnmRIvV7g==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+            "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
             "dev": true,
             "dependencies": {
-                "@floating-ui/core": "^0.7.0"
+                "@floating-ui/utils": "^0.1.3"
             }
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+            "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+            "dev": true,
+            "dependencies": {
+                "@floating-ui/core": "^1.4.2",
+                "@floating-ui/utils": "^0.1.3"
+            }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
+            "integrity": "sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA==",
+            "dev": true
         },
         "node_modules/@gar/promisify": {
             "version": "1.1.3",
@@ -10980,13 +10992,15 @@
             }
         },
         "node_modules/ariakit": {
-            "version": "2.0.0-next.27",
-            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.27.tgz",
-            "integrity": "sha512-PvZxNDARg6N/fKG1WW7L3UoOoXTBIeKYYTn6fUoBANbRS+K4u73wwkCVme8oWUzniUbNdx+w/pfvqZ8/cQyaUA==",
+            "version": "2.0.0-next.43",
+            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.43.tgz",
+            "integrity": "sha512-CatNgIMyurefYTEvp8aF3aQQGR5m9bZxYQXuqyw/MKwxJ/aJ295SSSY5pXyTHbbsgDI28GOKFYa5pfUBvkd7cQ==",
+            "deprecated": "The ariakit package has been renamed to @ariakit/react. Visit https://ariakit.org for more info.",
             "dev": true,
             "dependencies": {
-                "@floating-ui/dom": "0.5.0",
-                "ariakit-utils": "0.17.0-next.18"
+                "@floating-ui/dom": "^1.0.0",
+                "ariakit-react-utils": "0.17.0-next.27",
+                "ariakit-utils": "0.17.0-next.27"
             },
             "funding": {
                 "type": "opencollective",
@@ -10997,14 +11011,24 @@
                 "react-dom": "^17.0.0 || ^18.0.0"
             }
         },
-        "node_modules/ariakit-utils": {
-            "version": "0.17.0-next.18",
-            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.18.tgz",
-            "integrity": "sha512-uDPWUW850ootTSIeYWkDU83bjJeM+QB3WAurw0RUoqOsUbJOFqxG5opVikDhvelRMR8+gV52MC2v2iy10wxb7Q==",
+        "node_modules/ariakit-react-utils": {
+            "version": "0.17.0-next.27",
+            "resolved": "https://registry.npmjs.org/ariakit-react-utils/-/ariakit-react-utils-0.17.0-next.27.tgz",
+            "integrity": "sha512-YyL3sEowwaw6r8wRjENB9S4Hjz/ppyv5nJNeFkb6xaEX/QYUYmqL+lQch50LW04vj9oa8RGHlY2SmyQX3d7g3w==",
             "dev": true,
+            "dependencies": {
+                "ariakit-utils": "0.17.0-next.27"
+            },
             "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0",
                 "react": "^17.0.0 || ^18.0.0"
             }
+        },
+        "node_modules/ariakit-utils": {
+            "version": "0.17.0-next.27",
+            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.27.tgz",
+            "integrity": "sha512-IcjtuHl7FZP5mGrpvTSXqPUj+jRuIuBHlJAlxr3y4pxRgYpsYVpyZOClU3yrOoG7KUVApfmJjPOGWy00y+Gi+Q==",
+            "dev": true
         },
         "node_modules/arr-diff": {
             "version": "4.0.0",
@@ -30138,7 +30162,7 @@
                 "dayjs": "^1.9.1"
             },
             "devDependencies": {
-                "@doist/reactist": "^15.0.0",
+                "@doist/reactist": "^21.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -30162,7 +30186,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^15.0.0",
+                "@doist/reactist": "^21.0.0",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",
@@ -32138,20 +32162,22 @@
             "requires": {}
         },
         "@doist/reactist": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-15.0.0.tgz",
-            "integrity": "sha512-R32CKKeIrsCbOKGyOoBYjhXODyZNfBKnGDIkC65IgDGTmvriVYqKNXJ9uxt2+TgZmzFjFwI55ipsMvnSwnwERg==",
+            "version": "21.3.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-21.3.0.tgz",
+            "integrity": "sha512-dxgeNyhO6x9cbfv/pMhUmCRrTjY9ITpNtGJyG1diX6Ze7fyROuX8/L0f3H5jQtcahZRTXLG99IrPSZN6PamuYg==",
             "dev": true,
             "requires": {
                 "@reach/dialog": "^0.16.0",
                 "aria-hidden": "^1.2.1",
-                "ariakit": "2.0.0-next.27",
-                "ariakit-utils": "0.17.0-next.18",
+                "ariakit": "2.0.0-next.43",
+                "ariakit-react-utils": "0.17.0-next.27",
+                "ariakit-utils": "0.17.0-next.27",
                 "dayjs": "^1.8.10",
                 "patch-package": "^6.4.6",
                 "react-focus-lock": "^2.9.1",
                 "react-keyed-flatten-children": "^1.3.0",
-                "react-markdown": "^5.0.3"
+                "react-markdown": "^5.0.3",
+                "use-callback-ref": "^1.3.0"
             }
         },
         "@doist/tsconfig": {
@@ -32169,7 +32195,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
-                "@doist/reactist": "^15.0.0",
+                "@doist/reactist": "^21.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -32649,19 +32675,29 @@
             }
         },
         "@floating-ui/core": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.3.tgz",
-            "integrity": "sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==",
-            "dev": true
-        },
-        "@floating-ui/dom": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.0.tgz",
-            "integrity": "sha512-PS75dnMg4GdWjDFOiOs15cDzYJpukRNHqQn0ugrBlsrpk2n+y8bwZ24XrsdLSL7kxshmxxr2nTNycLnmRIvV7g==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+            "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
             "dev": true,
             "requires": {
-                "@floating-ui/core": "^0.7.0"
+                "@floating-ui/utils": "^0.1.3"
             }
+        },
+        "@floating-ui/dom": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+            "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+            "dev": true,
+            "requires": {
+                "@floating-ui/core": "^1.4.2",
+                "@floating-ui/utils": "^0.1.3"
+            }
+        },
+        "@floating-ui/utils": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
+            "integrity": "sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA==",
+            "dev": true
         },
         "@gar/promisify": {
             "version": "1.1.3",
@@ -38888,21 +38924,30 @@
             "dev": true
         },
         "ariakit": {
-            "version": "2.0.0-next.27",
-            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.27.tgz",
-            "integrity": "sha512-PvZxNDARg6N/fKG1WW7L3UoOoXTBIeKYYTn6fUoBANbRS+K4u73wwkCVme8oWUzniUbNdx+w/pfvqZ8/cQyaUA==",
+            "version": "2.0.0-next.43",
+            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.43.tgz",
+            "integrity": "sha512-CatNgIMyurefYTEvp8aF3aQQGR5m9bZxYQXuqyw/MKwxJ/aJ295SSSY5pXyTHbbsgDI28GOKFYa5pfUBvkd7cQ==",
             "dev": true,
             "requires": {
-                "@floating-ui/dom": "0.5.0",
-                "ariakit-utils": "0.17.0-next.18"
+                "@floating-ui/dom": "^1.0.0",
+                "ariakit-react-utils": "0.17.0-next.27",
+                "ariakit-utils": "0.17.0-next.27"
+            }
+        },
+        "ariakit-react-utils": {
+            "version": "0.17.0-next.27",
+            "resolved": "https://registry.npmjs.org/ariakit-react-utils/-/ariakit-react-utils-0.17.0-next.27.tgz",
+            "integrity": "sha512-YyL3sEowwaw6r8wRjENB9S4Hjz/ppyv5nJNeFkb6xaEX/QYUYmqL+lQch50LW04vj9oa8RGHlY2SmyQX3d7g3w==",
+            "dev": true,
+            "requires": {
+                "ariakit-utils": "0.17.0-next.27"
             }
         },
         "ariakit-utils": {
-            "version": "0.17.0-next.18",
-            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.18.tgz",
-            "integrity": "sha512-uDPWUW850ootTSIeYWkDU83bjJeM+QB3WAurw0RUoqOsUbJOFqxG5opVikDhvelRMR8+gV52MC2v2iy10wxb7Q==",
-            "dev": true,
-            "requires": {}
+            "version": "0.17.0-next.27",
+            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.27.tgz",
+            "integrity": "sha512-IcjtuHl7FZP5mGrpvTSXqPUj+jRuIuBHlJAlxr3y4pxRgYpsYVpyZOClU3yrOoG7KUVApfmJjPOGWy00y+Gi+Q==",
+            "dev": true
         },
         "arr-diff": {
             "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30155,7 +30155,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "9.2.0",
+            "version": "10.0.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",

--- a/packages/ui-extensions-react/.storybook/main.js
+++ b/packages/ui-extensions-react/.storybook/main.js
@@ -2,6 +2,9 @@ module.exports = {
     stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
     addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
     webpackFinal: async (config) => {
+        // Skip transpilation for node_modules, except for non-transpiled dependencies
+        config.module.rules[0].exclude = /node_modules\/(?!.*ariakit.*).*/
+
         config.module.rules.push({
             test: /\.(ts|tsx)$/,
             use: {

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "9.2.0",
+    "version": "10.0.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^15.0.0",
+        "@doist/reactist": "^21.0.0",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -48,7 +48,7 @@
         "dayjs": "^1.9.1"
     },
     "devDependencies": {
-        "@doist/reactist": "^15.0.0",
+        "@doist/reactist": "^21.0.0",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-essentials": "^6.3.12",
         "@storybook/addon-links": "^6.3.12",


### PR DESCRIPTION
In theory, none of Reactist's breaking changes from v15 to v21 affect the ui-extensions-react components. @scottlovegrove , can you double check?

Bumping the version to 10.0.0 (major) as a peer dependency version is changed, which forces consumers of this library to update it too.