### PR TITLE
chore: update Reactist to v22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2240,13 +2240,12 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "21.3.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-21.3.0.tgz",
-            "integrity": "sha512-dxgeNyhO6x9cbfv/pMhUmCRrTjY9ITpNtGJyG1diX6Ze7fyROuX8/L0f3H5jQtcahZRTXLG99IrPSZN6PamuYg==",
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-22.0.0.tgz",
+            "integrity": "sha512-d9B6CQDfbiv+VgruFKuq52xec8Xy5QyDP7lYuBkMZI78qfwktl4ZaDMBAHYHqwyae8LhQwhNuH8JfFOZPcdPVg==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@reach/dialog": "^0.16.0",
                 "aria-hidden": "^1.2.1",
                 "ariakit": "2.0.0-next.43",
                 "ariakit-react-utils": "0.17.0-next.27",
@@ -3347,53 +3346,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/@reach/dialog": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@reach/dialog/-/dialog-0.16.2.tgz",
-            "integrity": "sha512-qq8oX0cROgTb8LjOKWzzNm4SqaN9b89lJHr7UyVo2aQ6WbeNzZBxqXhGywFP7dkR+hNqOJnrA59PXFWhfttA9A==",
-            "dev": true,
-            "dependencies": {
-                "@reach/portal": "0.16.2",
-                "@reach/utils": "0.16.0",
-                "prop-types": "^15.7.2",
-                "react-focus-lock": "^2.5.2",
-                "react-remove-scroll": "^2.4.3",
-                "tslib": "^2.3.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || 17.x",
-                "react-dom": "^16.8.0 || 17.x"
-            }
-        },
-        "node_modules/@reach/portal": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
-            "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
-            "dev": true,
-            "dependencies": {
-                "@reach/utils": "0.16.0",
-                "tiny-warning": "^1.0.3",
-                "tslib": "^2.3.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || 17.x",
-                "react-dom": "^16.8.0 || 17.x"
-            }
-        },
-        "node_modules/@reach/utils": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-            "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-            "dev": true,
-            "dependencies": {
-                "tiny-warning": "^1.0.3",
-                "tslib": "^2.3.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || 17.x",
-                "react-dom": "^16.8.0 || 17.x"
             }
         },
         "node_modules/@rollup/plugin-commonjs": {
@@ -16514,9 +16466,9 @@
             }
         },
         "node_modules/focus-lock": {
-            "version": "0.11.2",
-            "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.2.tgz",
-            "integrity": "sha512-pZ2bO++NWLHhiKkgP1bEXHhR1/OjVcSvlCJ98aNJDFeb7H5OOQaO+SKOZle6041O9rv2tmbrO4JzClAvDUHf0g==",
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
+            "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
             "dev": true,
             "dependencies": {
                 "tslib": "^2.0.3"
@@ -17080,15 +17032,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-nonce": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/get-package-type": {
@@ -18351,15 +18294,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/invariant": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-            "dev": true,
-            "dependencies": {
-                "loose-envify": "^1.0.0"
             }
         },
         "node_modules/ip": {
@@ -24109,13 +24043,13 @@
             }
         },
         "node_modules/react-focus-lock": {
-            "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.1.tgz",
-            "integrity": "sha512-pSWOQrUmiKLkffPO6BpMXN7SNKXMsuOakl652IBuALAu1esk+IcpJyM+ALcYzPTTFz1rD0R54aB9A4HuP5t1Wg==",
+            "version": "2.9.5",
+            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+            "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.0.0",
-                "focus-lock": "^0.11.2",
+                "focus-lock": "^0.11.6",
                 "prop-types": "^15.6.2",
                 "react-clientside-effect": "^1.2.6",
                 "use-callback-ref": "^1.3.0",
@@ -24223,53 +24157,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-remove-scroll": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
-            "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
-            "dev": true,
-            "dependencies": {
-                "react-remove-scroll-bar": "^2.3.3",
-                "react-style-singleton": "^2.2.1",
-                "tslib": "^2.1.0",
-                "use-callback-ref": "^1.3.0",
-                "use-sidecar": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/react-remove-scroll-bar": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.3.tgz",
-            "integrity": "sha512-i9GMNWwpz8XpUpQ6QlevUtFjHGqnPG4Hxs+wlIJntu/xcsZVEpJcIV71K3ZkqNy2q3GfgvkD7y6t/Sv8ofYSbw==",
-            "dev": true,
-            "dependencies": {
-                "react-style-singleton": "^2.2.1",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/react-select": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.3.0.tgz",
@@ -24300,29 +24187,6 @@
             },
             "peerDependencies": {
                 "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/react-style-singleton": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-            "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
-            "dev": true,
-            "dependencies": {
-                "get-nonce": "^1.0.0",
-                "invariant": "^2.2.4",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
             }
         },
         "node_modules/react-syntax-highlighter": {
@@ -27233,12 +27097,6 @@
             "engines": {
                 "node": ">=0.6.0"
             }
-        },
-        "node_modules/tiny-warning": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-            "dev": true
         },
         "node_modules/tmp": {
             "version": "0.0.33",
@@ -30162,7 +30020,7 @@
                 "dayjs": "^1.9.1"
             },
             "devDependencies": {
-                "@doist/reactist": "^21.0.0",
+                "@doist/reactist": "^22.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -30186,7 +30044,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^21.0.0",
+                "@doist/reactist": "^22.0.0",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",
@@ -32162,12 +32020,11 @@
             "requires": {}
         },
         "@doist/reactist": {
-            "version": "21.3.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-21.3.0.tgz",
-            "integrity": "sha512-dxgeNyhO6x9cbfv/pMhUmCRrTjY9ITpNtGJyG1diX6Ze7fyROuX8/L0f3H5jQtcahZRTXLG99IrPSZN6PamuYg==",
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-22.0.0.tgz",
+            "integrity": "sha512-d9B6CQDfbiv+VgruFKuq52xec8Xy5QyDP7lYuBkMZI78qfwktl4ZaDMBAHYHqwyae8LhQwhNuH8JfFOZPcdPVg==",
             "dev": true,
             "requires": {
-                "@reach/dialog": "^0.16.0",
                 "aria-hidden": "^1.2.1",
                 "ariakit": "2.0.0-next.43",
                 "ariakit-react-utils": "0.17.0-next.27",
@@ -32195,7 +32052,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
-                "@doist/reactist": "^21.0.0",
+                "@doist/reactist": "^22.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -33362,41 +33219,6 @@
                     "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
                     "dev": true
                 }
-            }
-        },
-        "@reach/dialog": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@reach/dialog/-/dialog-0.16.2.tgz",
-            "integrity": "sha512-qq8oX0cROgTb8LjOKWzzNm4SqaN9b89lJHr7UyVo2aQ6WbeNzZBxqXhGywFP7dkR+hNqOJnrA59PXFWhfttA9A==",
-            "dev": true,
-            "requires": {
-                "@reach/portal": "0.16.2",
-                "@reach/utils": "0.16.0",
-                "prop-types": "^15.7.2",
-                "react-focus-lock": "^2.5.2",
-                "react-remove-scroll": "^2.4.3",
-                "tslib": "^2.3.0"
-            }
-        },
-        "@reach/portal": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
-            "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
-            "dev": true,
-            "requires": {
-                "@reach/utils": "0.16.0",
-                "tiny-warning": "^1.0.3",
-                "tslib": "^2.3.0"
-            }
-        },
-        "@reach/utils": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-            "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-            "dev": true,
-            "requires": {
-                "tiny-warning": "^1.0.3",
-                "tslib": "^2.3.0"
             }
         },
         "@rollup/plugin-commonjs": {
@@ -43274,9 +43096,9 @@
             }
         },
         "focus-lock": {
-            "version": "0.11.2",
-            "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.2.tgz",
-            "integrity": "sha512-pZ2bO++NWLHhiKkgP1bEXHhR1/OjVcSvlCJ98aNJDFeb7H5OOQaO+SKOZle6041O9rv2tmbrO4JzClAvDUHf0g==",
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
+            "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
             "dev": true,
             "requires": {
                 "tslib": "^2.0.3"
@@ -43724,12 +43546,6 @@
                 "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3"
             }
-        },
-        "get-nonce": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-            "dev": true
         },
         "get-package-type": {
             "version": "0.1.0",
@@ -44661,15 +44477,6 @@
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
-        },
-        "invariant": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-            "dev": true,
-            "requires": {
-                "loose-envify": "^1.0.0"
-            }
         },
         "ip": {
             "version": "2.0.0",
@@ -49033,13 +48840,13 @@
             }
         },
         "react-focus-lock": {
-            "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.1.tgz",
-            "integrity": "sha512-pSWOQrUmiKLkffPO6BpMXN7SNKXMsuOakl652IBuALAu1esk+IcpJyM+ALcYzPTTFz1rD0R54aB9A4HuP5t1Wg==",
+            "version": "2.9.5",
+            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+            "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.0.0",
-                "focus-lock": "^0.11.2",
+                "focus-lock": "^0.11.6",
                 "prop-types": "^15.6.2",
                 "react-clientside-effect": "^1.2.6",
                 "use-callback-ref": "^1.3.0",
@@ -49121,29 +48928,6 @@
             "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
             "dev": true
         },
-        "react-remove-scroll": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
-            "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
-            "dev": true,
-            "requires": {
-                "react-remove-scroll-bar": "^2.3.3",
-                "react-style-singleton": "^2.2.1",
-                "tslib": "^2.1.0",
-                "use-callback-ref": "^1.3.0",
-                "use-sidecar": "^1.1.2"
-            }
-        },
-        "react-remove-scroll-bar": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.3.tgz",
-            "integrity": "sha512-i9GMNWwpz8XpUpQ6QlevUtFjHGqnPG4Hxs+wlIJntu/xcsZVEpJcIV71K3ZkqNy2q3GfgvkD7y6t/Sv8ofYSbw==",
-            "dev": true,
-            "requires": {
-                "react-style-singleton": "^2.2.1",
-                "tslib": "^2.0.0"
-            }
-        },
         "react-select": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.3.0.tgz",
@@ -49167,17 +48951,6 @@
             "requires": {
                 "object-assign": "^4.1.1",
                 "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
-        "react-style-singleton": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-            "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
-            "dev": true,
-            "requires": {
-                "get-nonce": "^1.0.0",
-                "invariant": "^2.2.4",
-                "tslib": "^2.0.0"
             }
         },
         "react-syntax-highlighter": {
@@ -51482,12 +51255,6 @@
             "requires": {
                 "setimmediate": "^1.0.4"
             }
-        },
-        "tiny-warning": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-            "dev": true
         },
         "tmp": {
             "version": "0.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30013,7 +30013,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "10.0.0",
+            "version": "11.0.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "10.0.0",
+    "version": "11.0.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^21.0.0",
+        "@doist/reactist": "^22.0.0",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -48,7 +48,7 @@
         "dayjs": "^1.9.1"
     },
     "devDependencies": {
-        "@doist/reactist": "^21.0.0",
+        "@doist/reactist": "^22.0.0",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-essentials": "^6.3.12",
         "@storybook/addon-links": "^6.3.12",


### PR DESCRIPTION
After today's Reactist update in this repo (https://github.com/Doist/ui-extensions/pull/55), a new Reactist version was released (v22.0.0). The breaking changes don't affect this library.

Bumping the version to 11.0.0 (major) as a peer dependency version is changed, which forces consumers of this library to update it too.