### PR TITLE
chore(deps): Upgrade Reactist to v24.0.0-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30089,7 +30089,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "12.0.0",
+            "version": "13.0.0-beta",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
@@ -30120,7 +30120,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^23.1.0",
+                "@doist/reactist": "24.0.0-beta",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "12.0.0",
+    "version": "13.0.0-beta",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^23.1.0",
+        "@doist/reactist": "24.0.0-beta",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",


### PR DESCRIPTION
This is an attempt to release a beta version of `@doist/ui-extensions-react`, one that uses the latest beta version of Reactist.