### PR TITLE
new stable release v13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30089,7 +30089,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "13.0.0-beta",
+            "version": "13.1.0-beta",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
@@ -30120,7 +30120,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "24.0.0-beta",
+                "@doist/reactist": "^24.1.0-beta",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30126,7 +30126,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^24.1.2-beta",
+                "@doist/reactist": "^24.1.3-beta",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30089,7 +30089,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "12.0.0",
+            "version": "13.0.0-beta",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
@@ -30120,7 +30120,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^23.1.0",
+                "@doist/reactist": "24.0.0-beta",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2344,9 +2344,9 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "24.1.1-beta",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-24.1.1-beta.tgz",
-            "integrity": "sha512-ExJRgG8XbGm6iHdULcRYBq5rq8/dVqmEzm3LOcBFygYX3JlXCksJiZloln3wU74K1fGJrUdFxuhKY5l2p3OS0w==",
+            "version": "24.1.2-beta",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-24.1.2-beta.tgz",
+            "integrity": "sha512-0I83e+g+0+hkdU4uK6apL/3Hx/z1pe6MpJDRWeN0VIFh34jwfqclE3dxzIBNyGkclH1h0fjDqbAcMJPaKXmf9w==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -30095,14 +30095,14 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "13.1.1-beta",
+            "version": "13.1.2-beta",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
                 "dayjs": "^1.9.1"
             },
             "devDependencies": {
-                "@doist/reactist": "^24.1.1-beta",
+                "@doist/reactist": "^24.1.2-beta",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -30126,7 +30126,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^24.1.1-beta",
+                "@doist/reactist": "^24.1.2-beta",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",
@@ -32181,9 +32181,9 @@
             "requires": {}
         },
         "@doist/reactist": {
-            "version": "24.1.1-beta",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-24.1.1-beta.tgz",
-            "integrity": "sha512-ExJRgG8XbGm6iHdULcRYBq5rq8/dVqmEzm3LOcBFygYX3JlXCksJiZloln3wU74K1fGJrUdFxuhKY5l2p3OS0w==",
+            "version": "24.1.2-beta",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-24.1.2-beta.tgz",
+            "integrity": "sha512-0I83e+g+0+hkdU4uK6apL/3Hx/z1pe6MpJDRWeN0VIFh34jwfqclE3dxzIBNyGkclH1h0fjDqbAcMJPaKXmf9w==",
             "dev": true,
             "requires": {
                 "@ariakit/react": "^0.3.14",
@@ -32211,7 +32211,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
-                "@doist/reactist": "^24.1.1-beta",
+                "@doist/reactist": "^24.1.2-beta",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30095,7 +30095,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "13.1.2-beta",
+            "version": "13.1.4-beta",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
@@ -30126,7 +30126,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^24.1.3-beta",
+                "@doist/reactist": "^24.1.4-beta",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,44 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/@ariakit/core": {
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.11.tgz",
+            "integrity": "sha512-+MnOeqnA4FLI/7vqsZLbZQHHN4ofd9kvkNjz44fNi0gqmD+ZbMWiDkFAvZII75dYnxYw5ZPpWjA4waK22VBWig==",
+            "dev": true
+        },
+        "node_modules/@ariakit/react": {
+            "version": "0.3.14",
+            "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.14.tgz",
+            "integrity": "sha512-h71BPMZ2eW+E2ESbdYxSAEMR1DozYzd5eHE5IOzGd9Egi5u7EZxqmuW4CXVXZ1Y6vbaDMV3SudgPh7iHS/ArFw==",
+            "dev": true,
+            "dependencies": {
+                "@ariakit/react-core": "0.3.14"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ariakit"
+            },
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@ariakit/react-core": {
+            "version": "0.3.14",
+            "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.14.tgz",
+            "integrity": "sha512-16Qj6kDPglpdWtU5roY9q+G66naOjauTY5HvUIaL2aLY0187ATaRrABIKoMMzTtJyhvsud4jFlzivz+/zCQ8yw==",
+            "dev": true,
+            "dependencies": {
+                "@ariakit/core": "0.3.11",
+                "@floating-ui/dom": "^1.0.0",
+                "use-sync-external-store": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/@babel/code-frame": {
             "version": "7.23.5",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
@@ -2306,16 +2344,14 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-23.1.0.tgz",
-            "integrity": "sha512-4/+Z/o5EpgNNl1+IBhcB8yOH2g2+4M/h8XiPNAbzT1BIRuEM8LiqA9CdABObdDxUORQaAP8OUbt9MWnIepebnQ==",
+            "version": "24.1.1-beta",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-24.1.1-beta.tgz",
+            "integrity": "sha512-ExJRgG8XbGm6iHdULcRYBq5rq8/dVqmEzm3LOcBFygYX3JlXCksJiZloln3wU74K1fGJrUdFxuhKY5l2p3OS0w==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
+                "@ariakit/react": "^0.3.14",
                 "aria-hidden": "^1.2.1",
-                "ariakit": "2.0.0-next.43",
-                "ariakit-react-utils": "0.17.0-next.27",
-                "ariakit-utils": "0.17.0-next.27",
                 "dayjs": "^1.8.10",
                 "patch-package": "^6.4.6",
                 "react-focus-lock": "^2.9.1",
@@ -2509,28 +2545,28 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
-            "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+            "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
             "dev": true,
             "dependencies": {
-                "@floating-ui/utils": "^0.1.3"
+                "@floating-ui/utils": "^0.2.1"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
-            "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+            "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
             "dev": true,
             "dependencies": {
-                "@floating-ui/core": "^1.4.2",
-                "@floating-ui/utils": "^0.1.3"
+                "@floating-ui/core": "^1.0.0",
+                "@floating-ui/utils": "^0.2.0"
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
-            "integrity": "sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+            "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
             "dev": true
         },
         "node_modules/@gar/promisify": {
@@ -11008,45 +11044,6 @@
             "engines": {
                 "node": ">=6.0"
             }
-        },
-        "node_modules/ariakit": {
-            "version": "2.0.0-next.43",
-            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.43.tgz",
-            "integrity": "sha512-CatNgIMyurefYTEvp8aF3aQQGR5m9bZxYQXuqyw/MKwxJ/aJ295SSSY5pXyTHbbsgDI28GOKFYa5pfUBvkd7cQ==",
-            "deprecated": "The ariakit package has been renamed to @ariakit/react. Visit https://ariakit.org for more info.",
-            "dev": true,
-            "dependencies": {
-                "@floating-ui/dom": "^1.0.0",
-                "ariakit-react-utils": "0.17.0-next.27",
-                "ariakit-utils": "0.17.0-next.27"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/ariakit"
-            },
-            "peerDependencies": {
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/ariakit-react-utils": {
-            "version": "0.17.0-next.27",
-            "resolved": "https://registry.npmjs.org/ariakit-react-utils/-/ariakit-react-utils-0.17.0-next.27.tgz",
-            "integrity": "sha512-YyL3sEowwaw6r8wRjENB9S4Hjz/ppyv5nJNeFkb6xaEX/QYUYmqL+lQch50LW04vj9oa8RGHlY2SmyQX3d7g3w==",
-            "dev": true,
-            "dependencies": {
-                "ariakit-utils": "0.17.0-next.27"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0",
-                "react": "^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/ariakit-utils": {
-            "version": "0.17.0-next.27",
-            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.27.tgz",
-            "integrity": "sha512-IcjtuHl7FZP5mGrpvTSXqPUj+jRuIuBHlJAlxr3y4pxRgYpsYVpyZOClU3yrOoG7KUVApfmJjPOGWy00y+Gi+Q==",
-            "dev": true
         },
         "node_modules/arr-diff": {
             "version": "4.0.0",
@@ -28313,6 +28310,15 @@
                 }
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "dev": true,
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/util": {
             "version": "0.11.1",
             "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -30089,14 +30095,14 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "13.1.0-beta",
+            "version": "13.1.1-beta",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
                 "dayjs": "^1.9.1"
             },
             "devDependencies": {
-                "@doist/reactist": "^23.1.0",
+                "@doist/reactist": "^24.1.1-beta",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -30120,7 +30126,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^24.1.0-beta",
+                "@doist/reactist": "^24.1.1-beta",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",
@@ -30582,6 +30588,32 @@
             "requires": {
                 "@jridgewell/gen-mapping": "^0.1.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
+            }
+        },
+        "@ariakit/core": {
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.11.tgz",
+            "integrity": "sha512-+MnOeqnA4FLI/7vqsZLbZQHHN4ofd9kvkNjz44fNi0gqmD+ZbMWiDkFAvZII75dYnxYw5ZPpWjA4waK22VBWig==",
+            "dev": true
+        },
+        "@ariakit/react": {
+            "version": "0.3.14",
+            "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.14.tgz",
+            "integrity": "sha512-h71BPMZ2eW+E2ESbdYxSAEMR1DozYzd5eHE5IOzGd9Egi5u7EZxqmuW4CXVXZ1Y6vbaDMV3SudgPh7iHS/ArFw==",
+            "dev": true,
+            "requires": {
+                "@ariakit/react-core": "0.3.14"
+            }
+        },
+        "@ariakit/react-core": {
+            "version": "0.3.14",
+            "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.14.tgz",
+            "integrity": "sha512-16Qj6kDPglpdWtU5roY9q+G66naOjauTY5HvUIaL2aLY0187ATaRrABIKoMMzTtJyhvsud4jFlzivz+/zCQ8yw==",
+            "dev": true,
+            "requires": {
+                "@ariakit/core": "0.3.11",
+                "@floating-ui/dom": "^1.0.0",
+                "use-sync-external-store": "^1.2.0"
             }
         },
         "@babel/code-frame": {
@@ -32149,15 +32181,13 @@
             "requires": {}
         },
         "@doist/reactist": {
-            "version": "23.1.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-23.1.0.tgz",
-            "integrity": "sha512-4/+Z/o5EpgNNl1+IBhcB8yOH2g2+4M/h8XiPNAbzT1BIRuEM8LiqA9CdABObdDxUORQaAP8OUbt9MWnIepebnQ==",
+            "version": "24.1.1-beta",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-24.1.1-beta.tgz",
+            "integrity": "sha512-ExJRgG8XbGm6iHdULcRYBq5rq8/dVqmEzm3LOcBFygYX3JlXCksJiZloln3wU74K1fGJrUdFxuhKY5l2p3OS0w==",
             "dev": true,
             "requires": {
+                "@ariakit/react": "^0.3.14",
                 "aria-hidden": "^1.2.1",
-                "ariakit": "2.0.0-next.43",
-                "ariakit-react-utils": "0.17.0-next.27",
-                "ariakit-utils": "0.17.0-next.27",
                 "dayjs": "^1.8.10",
                 "patch-package": "^6.4.6",
                 "react-focus-lock": "^2.9.1",
@@ -32181,7 +32211,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
-                "@doist/reactist": "^23.1.0",
+                "@doist/reactist": "^24.1.1-beta",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -32661,28 +32691,28 @@
             }
         },
         "@floating-ui/core": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
-            "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+            "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
             "dev": true,
             "requires": {
-                "@floating-ui/utils": "^0.1.3"
+                "@floating-ui/utils": "^0.2.1"
             }
         },
         "@floating-ui/dom": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
-            "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+            "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
             "dev": true,
             "requires": {
-                "@floating-ui/core": "^1.4.2",
-                "@floating-ui/utils": "^0.1.3"
+                "@floating-ui/core": "^1.0.0",
+                "@floating-ui/utils": "^0.2.0"
             }
         },
         "@floating-ui/utils": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
-            "integrity": "sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+            "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
             "dev": true
         },
         "@gar/promisify": {
@@ -38872,32 +38902,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
             "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
-            "dev": true
-        },
-        "ariakit": {
-            "version": "2.0.0-next.43",
-            "resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.43.tgz",
-            "integrity": "sha512-CatNgIMyurefYTEvp8aF3aQQGR5m9bZxYQXuqyw/MKwxJ/aJ295SSSY5pXyTHbbsgDI28GOKFYa5pfUBvkd7cQ==",
-            "dev": true,
-            "requires": {
-                "@floating-ui/dom": "^1.0.0",
-                "ariakit-react-utils": "0.17.0-next.27",
-                "ariakit-utils": "0.17.0-next.27"
-            }
-        },
-        "ariakit-react-utils": {
-            "version": "0.17.0-next.27",
-            "resolved": "https://registry.npmjs.org/ariakit-react-utils/-/ariakit-react-utils-0.17.0-next.27.tgz",
-            "integrity": "sha512-YyL3sEowwaw6r8wRjENB9S4Hjz/ppyv5nJNeFkb6xaEX/QYUYmqL+lQch50LW04vj9oa8RGHlY2SmyQX3d7g3w==",
-            "dev": true,
-            "requires": {
-                "ariakit-utils": "0.17.0-next.27"
-            }
-        },
-        "ariakit-utils": {
-            "version": "0.17.0-next.27",
-            "resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.27.tgz",
-            "integrity": "sha512-IcjtuHl7FZP5mGrpvTSXqPUj+jRuIuBHlJAlxr3y4pxRgYpsYVpyZOClU3yrOoG7KUVApfmJjPOGWy00y+Gi+Q==",
             "dev": true
         },
         "arr-diff": {
@@ -52198,6 +52202,13 @@
                 "detect-node-es": "^1.1.0",
                 "tslib": "^2.0.0"
             }
+        },
+        "use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "dev": true,
+            "requires": {}
         },
         "util": {
             "version": "0.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,18 +61,18 @@
             }
         },
         "node_modules/@ariakit/core": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.11.tgz",
-            "integrity": "sha512-+MnOeqnA4FLI/7vqsZLbZQHHN4ofd9kvkNjz44fNi0gqmD+ZbMWiDkFAvZII75dYnxYw5ZPpWjA4waK22VBWig==",
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.5.tgz",
+            "integrity": "sha512-e294+bEcyzt/H/kO4fS5/czLAlkF7PY+Kul3q2z54VY+GGay8NlVs9UezAB7L4jUBlYRAXwp7/1Sq3R7b+MZ7w==",
             "dev": true
         },
         "node_modules/@ariakit/react": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.14.tgz",
-            "integrity": "sha512-h71BPMZ2eW+E2ESbdYxSAEMR1DozYzd5eHE5IOzGd9Egi5u7EZxqmuW4CXVXZ1Y6vbaDMV3SudgPh7iHS/ArFw==",
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.5.tgz",
+            "integrity": "sha512-GUHxaOY1JZrJUHkuV20IY4NWcgknhqTQM0qCQcVZDCi+pJiWchUjTG+UyIr/Of02hU569qnQ7yovskCf+V3tNg==",
             "dev": true,
             "dependencies": {
-                "@ariakit/react-core": "0.3.14"
+                "@ariakit/react-core": "0.4.5"
             },
             "funding": {
                 "type": "opencollective",
@@ -84,12 +84,12 @@
             }
         },
         "node_modules/@ariakit/react-core": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.14.tgz",
-            "integrity": "sha512-16Qj6kDPglpdWtU5roY9q+G66naOjauTY5HvUIaL2aLY0187ATaRrABIKoMMzTtJyhvsud4jFlzivz+/zCQ8yw==",
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.5.tgz",
+            "integrity": "sha512-ciTYPwpj/+mdA+EstveEnoygbx5e4PXQJxfkLKy4lkTkDJJUS9GcbYhdnIFJVUta6P1YFvzkIKo+/y9mcbMKJg==",
             "dev": true,
             "dependencies": {
-                "@ariakit/core": "0.3.11",
+                "@ariakit/core": "0.4.5",
                 "@floating-ui/dom": "^1.0.0",
                 "use-sync-external-store": "^1.2.0"
             },
@@ -2344,13 +2344,13 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "24.1.2-beta",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-24.1.2-beta.tgz",
-            "integrity": "sha512-0I83e+g+0+hkdU4uK6apL/3Hx/z1pe6MpJDRWeN0VIFh34jwfqclE3dxzIBNyGkclH1h0fjDqbAcMJPaKXmf9w==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-25.0.0.tgz",
+            "integrity": "sha512-Nk2M8Lt5NFJXiuZzaQRxlwJaGc1c3MPIKAfchKhZxv4V5QlCd/XDyRBLtHdVAhi/e0WklJ52FzsDD5z7mbCJtQ==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@ariakit/react": "^0.3.14",
+                "@ariakit/react": "0.4.5",
                 "aria-hidden": "^1.2.1",
                 "dayjs": "^1.8.10",
                 "patch-package": "^6.4.6",
@@ -2545,28 +2545,28 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-            "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+            "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
             "dev": true,
             "dependencies": {
-                "@floating-ui/utils": "^0.2.1"
+                "@floating-ui/utils": "^0.2.7"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-            "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+            "version": "1.6.10",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+            "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
             "dev": true,
             "dependencies": {
-                "@floating-ui/core": "^1.0.0",
-                "@floating-ui/utils": "^0.2.0"
+                "@floating-ui/core": "^1.6.0",
+                "@floating-ui/utils": "^0.2.7"
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-            "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+            "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
             "dev": true
         },
         "node_modules/@gar/promisify": {
@@ -28311,9 +28311,9 @@
             }
         },
         "node_modules/use-sync-external-store": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+            "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
             "dev": true,
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
@@ -30095,14 +30095,14 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "13.1.5-beta",
+            "version": "13.0.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
                 "dayjs": "^1.9.1"
             },
             "devDependencies": {
-                "@doist/reactist": "^24.1.2-beta",
+                "@doist/reactist": "^25.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -30126,7 +30126,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^24.2.0-beta",
+                "@doist/reactist": "^25.0.0",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",
@@ -30591,27 +30591,27 @@
             }
         },
         "@ariakit/core": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.11.tgz",
-            "integrity": "sha512-+MnOeqnA4FLI/7vqsZLbZQHHN4ofd9kvkNjz44fNi0gqmD+ZbMWiDkFAvZII75dYnxYw5ZPpWjA4waK22VBWig==",
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.5.tgz",
+            "integrity": "sha512-e294+bEcyzt/H/kO4fS5/czLAlkF7PY+Kul3q2z54VY+GGay8NlVs9UezAB7L4jUBlYRAXwp7/1Sq3R7b+MZ7w==",
             "dev": true
         },
         "@ariakit/react": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.14.tgz",
-            "integrity": "sha512-h71BPMZ2eW+E2ESbdYxSAEMR1DozYzd5eHE5IOzGd9Egi5u7EZxqmuW4CXVXZ1Y6vbaDMV3SudgPh7iHS/ArFw==",
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.5.tgz",
+            "integrity": "sha512-GUHxaOY1JZrJUHkuV20IY4NWcgknhqTQM0qCQcVZDCi+pJiWchUjTG+UyIr/Of02hU569qnQ7yovskCf+V3tNg==",
             "dev": true,
             "requires": {
-                "@ariakit/react-core": "0.3.14"
+                "@ariakit/react-core": "0.4.5"
             }
         },
         "@ariakit/react-core": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.14.tgz",
-            "integrity": "sha512-16Qj6kDPglpdWtU5roY9q+G66naOjauTY5HvUIaL2aLY0187ATaRrABIKoMMzTtJyhvsud4jFlzivz+/zCQ8yw==",
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.5.tgz",
+            "integrity": "sha512-ciTYPwpj/+mdA+EstveEnoygbx5e4PXQJxfkLKy4lkTkDJJUS9GcbYhdnIFJVUta6P1YFvzkIKo+/y9mcbMKJg==",
             "dev": true,
             "requires": {
-                "@ariakit/core": "0.3.11",
+                "@ariakit/core": "0.4.5",
                 "@floating-ui/dom": "^1.0.0",
                 "use-sync-external-store": "^1.2.0"
             }
@@ -32181,12 +32181,12 @@
             "requires": {}
         },
         "@doist/reactist": {
-            "version": "24.1.2-beta",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-24.1.2-beta.tgz",
-            "integrity": "sha512-0I83e+g+0+hkdU4uK6apL/3Hx/z1pe6MpJDRWeN0VIFh34jwfqclE3dxzIBNyGkclH1h0fjDqbAcMJPaKXmf9w==",
+            "version": "25.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-25.0.0.tgz",
+            "integrity": "sha512-Nk2M8Lt5NFJXiuZzaQRxlwJaGc1c3MPIKAfchKhZxv4V5QlCd/XDyRBLtHdVAhi/e0WklJ52FzsDD5z7mbCJtQ==",
             "dev": true,
             "requires": {
-                "@ariakit/react": "^0.3.14",
+                "@ariakit/react": "0.4.5",
                 "aria-hidden": "^1.2.1",
                 "dayjs": "^1.8.10",
                 "patch-package": "^6.4.6",
@@ -32211,7 +32211,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
-                "@doist/reactist": "^24.1.2-beta",
+                "@doist/reactist": "^25.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -32691,28 +32691,28 @@
             }
         },
         "@floating-ui/core": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-            "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+            "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
             "dev": true,
             "requires": {
-                "@floating-ui/utils": "^0.2.1"
+                "@floating-ui/utils": "^0.2.7"
             }
         },
         "@floating-ui/dom": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-            "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+            "version": "1.6.10",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+            "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
             "dev": true,
             "requires": {
-                "@floating-ui/core": "^1.0.0",
-                "@floating-ui/utils": "^0.2.0"
+                "@floating-ui/core": "^1.6.0",
+                "@floating-ui/utils": "^0.2.7"
             }
         },
         "@floating-ui/utils": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-            "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+            "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
             "dev": true
         },
         "@gar/promisify": {
@@ -52204,9 +52204,9 @@
             }
         },
         "use-sync-external-store": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+            "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
             "dev": true,
             "requires": {}
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30095,7 +30095,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "13.1.4-beta",
+            "version": "13.1.5-beta",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
@@ -30126,7 +30126,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^24.1.4-beta",
+                "@doist/reactist": "^24.2.0-beta",
                 "@doist/ui-extensions-core": "^4.1.1",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "13.1.5-beta",
+    "version": "13.0.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^24.2.0-beta",
+        "@doist/reactist": "^25.0.0",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -48,7 +48,7 @@
         "dayjs": "^1.9.1"
     },
     "devDependencies": {
-        "@doist/reactist": "^24.1.2-beta",
+        "@doist/reactist": "^25.0.0",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-essentials": "^6.3.12",
         "@storybook/addon-links": "^6.3.12",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "13.0.0-beta",
+    "version": "13.1.0-beta",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "24.0.0-beta",
+        "@doist/reactist": "^24.1.0-beta",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "13.1.3-beta",
+    "version": "13.1.4-beta",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^24.1.3-beta",
+        "@doist/reactist": "^24.1.4-beta",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "13.1.1-beta",
+    "version": "13.1.2-beta",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^24.1.1-beta",
+        "@doist/reactist": "^24.1.2-beta",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -48,7 +48,7 @@
         "dayjs": "^1.9.1"
     },
     "devDependencies": {
-        "@doist/reactist": "^24.1.1-beta",
+        "@doist/reactist": "^24.1.2-beta",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-essentials": "^6.3.12",
         "@storybook/addon-links": "^6.3.12",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "13.1.2-beta",
+    "version": "13.1.3-beta",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^24.1.2-beta",
+        "@doist/reactist": "^24.1.3-beta",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "13.1.0-beta",
+    "version": "13.1.1-beta",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^24.1.0-beta",
+        "@doist/reactist": "^24.1.1-beta",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -48,7 +48,7 @@
         "dayjs": "^1.9.1"
     },
     "devDependencies": {
-        "@doist/reactist": "^23.1.0",
+        "@doist/reactist": "^24.1.1-beta",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-essentials": "^6.3.12",
         "@storybook/addon-links": "^6.3.12",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "13.1.4-beta",
+    "version": "13.1.5-beta",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^24.1.4-beta",
+        "@doist/reactist": "^24.2.0-beta",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "12.0.0",
+    "version": "13.0.0-beta",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^23.1.0",
+        "@doist/reactist": "24.0.0-beta",
         "@doist/ui-extensions-core": "^4.1.1",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",


### PR DESCRIPTION
Now that Reactist is back to having all the new changes in a stable non-beta release (v25.0.0), this pull request brings that Reactist version to the ui-extensions, and brings this repo's recent changes in `next` back to `main`.

This pull request will be released as a new version v13.0.0 of the ui extensions react package.