### PR TITLE
chore: Bump '@doist/reactist' to 'v27.0.0'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2344,11 +2344,11 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "26.0.0",
-            "resolved": "git+ssh://git@github.com/Doist/reactist.git#3f63c70966002ba0bebf8454ef3611b73d7afa4c",
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-27.0.0.tgz",
+            "integrity": "sha512-TOuylR8OvOkEeruCepa54YUrCOjUeID1z1hhWsK+CWW540ZTql/BSqwYsLls3EBEkB0EKgb2U6Gd4aSE5nSoaQ==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "dependencies": {
                 "@ariakit/react": "0.4.5",
                 "aria-hidden": "^1.2.1",
@@ -30095,14 +30095,14 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "13.0.0",
+            "version": "14.0.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "^2.3.1",
                 "dayjs": "^1.9.1"
             },
             "devDependencies": {
-                "@doist/reactist": "^26.0.0",
+                "@doist/reactist": "^27.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",
@@ -30126,7 +30126,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^26.0.0",
+                "@doist/reactist": "^27.0.0",
                 "@doist/ui-extensions-core": "^4.2.0",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",
@@ -32181,9 +32181,10 @@
             "requires": {}
         },
         "@doist/reactist": {
-            "version": "git+ssh://git@github.com/Doist/reactist.git#3f63c70966002ba0bebf8454ef3611b73d7afa4c",
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-27.0.0.tgz",
+            "integrity": "sha512-TOuylR8OvOkEeruCepa54YUrCOjUeID1z1hhWsK+CWW540ZTql/BSqwYsLls3EBEkB0EKgb2U6Gd4aSE5nSoaQ==",
             "dev": true,
-            "from": "@doist/reactist@^26.0.0",
             "requires": {
                 "@ariakit/react": "0.4.5",
                 "aria-hidden": "^1.2.1",
@@ -32210,7 +32211,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
-                "@doist/reactist": "^26.0.0",
+                "@doist/reactist": "^27.0.0",
                 "@storybook/addon-actions": "^6.3.12",
                 "@storybook/addon-essentials": "^6.3.12",
                 "@storybook/addon-links": "^6.3.12",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^26.0.0",
+        "@doist/reactist": "^27.0.0",
         "@doist/ui-extensions-core": "^4.2.0",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -48,7 +48,7 @@
         "dayjs": "^1.9.1"
     },
     "devDependencies": {
-        "@doist/reactist": "^26.0.0",
+        "@doist/reactist": "^27.0.0",
         "@storybook/addon-actions": "^6.3.12",
         "@storybook/addon-essentials": "^6.3.12",
         "@storybook/addon-links": "^6.3.12",


### PR DESCRIPTION
## Overview

This PR bumps both the dev and peer dependency of `@doist/reactist` to `v27.0.0`.