### PR TITLE
chore(deps): Bump Reactist to v28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2300,9 +2300,9 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "27.5.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-27.5.0.tgz",
-            "integrity": "sha512-w/zoqm4pvXmdNfHMRPv89bB4abDGaPz0cOsozGvo8NcYdbQfBA7s49/FL1e90j3ql62NTZj0z/WKOUd7DGMAxQ==",
+            "version": "28.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-28.0.0.tgz",
+            "integrity": "sha512-MjgCJUHxwHeoSP+DpIxR6M8rfaXlfw4zk7+p7wSRX1/4owWHg8RgASCzuRt+Ojgth6v7fpIo6/qEz5dRzaq9Bw==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -27758,7 +27758,7 @@
                 "dayjs": "1.11.13"
             },
             "devDependencies": {
-                "@doist/reactist": "27.5.0",
+                "@doist/reactist": "28.0.0",
                 "@storybook/addon-actions": "6.5.16",
                 "@storybook/addon-essentials": "6.5.16",
                 "@storybook/addon-links": "6.5.16",
@@ -27782,7 +27782,7 @@
                 "node": ">=16"
             },
             "peerDependencies": {
-                "@doist/reactist": "^27.0.0",
+                "@doist/reactist": "^28.0.0",
                 "@doist/ui-extensions-core": "^4.2.0",
                 "adaptivecards": "^2.9.0",
                 "react": "^17.0.0 || ^18.0.0",
@@ -29801,9 +29801,9 @@
             "requires": {}
         },
         "@doist/reactist": {
-            "version": "27.5.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-27.5.0.tgz",
-            "integrity": "sha512-w/zoqm4pvXmdNfHMRPv89bB4abDGaPz0cOsozGvo8NcYdbQfBA7s49/FL1e90j3ql62NTZj0z/WKOUd7DGMAxQ==",
+            "version": "28.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-28.0.0.tgz",
+            "integrity": "sha512-MjgCJUHxwHeoSP+DpIxR6M8rfaXlfw4zk7+p7wSRX1/4owWHg8RgASCzuRt+Ojgth6v7fpIo6/qEz5dRzaq9Bw==",
             "dev": true,
             "requires": {
                 "@ariakit/react": "0.4.5",
@@ -29831,7 +29831,7 @@
         "@doist/ui-extensions-react": {
             "version": "file:packages/ui-extensions-react",
             "requires": {
-                "@doist/reactist": "27.5.0",
+                "@doist/reactist": "28.0.0",
                 "@storybook/addon-actions": "6.5.16",
                 "@storybook/addon-essentials": "6.5.16",
                 "@storybook/addon-links": "6.5.16",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -35,7 +35,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^27.0.0",
+        "@doist/reactist": "^28.0.0",
         "@doist/ui-extensions-core": "^4.2.0",
         "adaptivecards": "^2.9.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -48,7 +48,7 @@
         "dayjs": "1.11.13"
     },
     "devDependencies": {
-        "@doist/reactist": "27.5.0",
+        "@doist/reactist": "28.0.0",
         "@storybook/addon-actions": "6.5.16",
         "@storybook/addon-essentials": "6.5.16",
         "@storybook/addon-links": "6.5.16",


### PR DESCRIPTION
## Overview

This PR bumps both the dev and peer dependency of `@doist/reactist` to `v28.0.0`.