### PR TITLE
chore: Bump `@doist/ui-extensions-react` to v16

### DIFF
--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "15.0.0",
+    "version": "16.0.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",


### PR DESCRIPTION
To release https://github.com/Doist/ui-extensions/pull/114.