### PR TITLE
fix: migrate TimePicker off deprecated Reactist Select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8537,6 +8537,30 @@
                 "url": "https://github.com/sponsors/gregberge"
             }
         },
+        "node_modules/@svgr/webpack": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-8.1.0.tgz",
+            "integrity": "sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.21.3",
+                "@babel/plugin-transform-react-constant-elements": "^7.21.3",
+                "@babel/preset-env": "^7.20.2",
+                "@babel/preset-react": "^7.18.6",
+                "@babel/preset-typescript": "^7.21.0",
+                "@svgr/core": "8.1.0",
+                "@svgr/plugin-jsx": "8.1.0",
+                "@svgr/plugin-svgo": "8.1.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/gregberge"
+            }
+        },
         "node_modules/@swc/core": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.0.tgz",
@@ -30646,6 +30670,7 @@
                 "@storybook/react": "7.6.24",
                 "@storybook/react-webpack5": "7.6.24",
                 "@svgr/rollup": "8.1.0",
+                "@svgr/webpack": "8.1.0",
                 "@testing-library/dom": "10.4.1",
                 "@testing-library/jest-dom": "5.17.0",
                 "@testing-library/react": "9.5.0",
@@ -32174,6 +32199,7 @@
                 "@storybook/react": "7.6.24",
                 "@storybook/react-webpack5": "7.6.24",
                 "@svgr/rollup": "8.1.0",
+                "@svgr/webpack": "8.1.0",
                 "@testing-library/dom": "10.4.1",
                 "@testing-library/jest-dom": "5.17.0",
                 "@testing-library/react": "9.5.0",
@@ -36170,6 +36196,22 @@
                 "@babel/preset-react": "^7.18.6",
                 "@babel/preset-typescript": "^7.21.0",
                 "@rollup/pluginutils": "^5.0.2",
+                "@svgr/core": "8.1.0",
+                "@svgr/plugin-jsx": "8.1.0",
+                "@svgr/plugin-svgo": "8.1.0"
+            }
+        },
+        "@svgr/webpack": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-8.1.0.tgz",
+            "integrity": "sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.21.3",
+                "@babel/plugin-transform-react-constant-elements": "^7.21.3",
+                "@babel/preset-env": "^7.20.2",
+                "@babel/preset-react": "^7.18.6",
+                "@babel/preset-typescript": "^7.21.0",
                 "@svgr/core": "8.1.0",
                 "@svgr/plugin-jsx": "8.1.0",
                 "@svgr/plugin-svgo": "8.1.0"

--- a/packages/ui-extensions-react/.storybook/main.js
+++ b/packages/ui-extensions-react/.storybook/main.js
@@ -16,6 +16,20 @@ module.exports = {
                 loader: 'ts-loader',
             },
         })
+
+        // Handle SVG imports as React components (matching the @svgr/rollup setup used by
+        // the build), instead of Storybook's default asset/URL handling.
+        const assetRule = config.module.rules.find(
+            (rule) => rule.test instanceof RegExp && rule.test.test('.svg'),
+        )
+        if (assetRule) {
+            assetRule.exclude = /\.svg$/
+        }
+        config.module.rules.push({
+            test: /\.svg$/,
+            use: ['@svgr/webpack'],
+        })
+
         config.resolve.extensions.push('.ts', '.tsx')
         return config
     },

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -57,6 +57,7 @@
         "@storybook/react": "7.6.24",
         "@storybook/react-webpack5": "7.6.24",
         "@svgr/rollup": "8.1.0",
+        "@svgr/webpack": "8.1.0",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "5.17.0",
         "@testing-library/react": "9.5.0",

--- a/packages/ui-extensions-react/src/components/time-picker/time-picker.module.css
+++ b/packages/ui-extensions-react/src/components/time-picker/time-picker.module.css
@@ -11,12 +11,22 @@
 
 .time_picker .svg_icon {
     position: absolute;
-    top: 5px;
+    top: 50%;
     left: 5px;
-    right: 0;
-    margin-top: 0;
+    transform: translateY(-50%);
     width: 24px;
     color: var(--time-picker-clock-color);
+    /* Sit above Reactist's SelectField select. */
+    z-index: 2;
+    pointer-events: none;
+}
+
+/* Same: keep Reactist's chevron above the select. */
+.time_picker select ~ svg {
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 2;
+    pointer-events: none;
 }
 
 .time_picker select {

--- a/packages/ui-extensions-react/src/components/time-picker/time-picker.stories.tsx
+++ b/packages/ui-extensions-react/src/components/time-picker/time-picker.stories.tsx
@@ -1,0 +1,32 @@
+import '@doist/reactist/styles/reactist.css'
+
+import { TimePicker } from './time-picker'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta: Meta<typeof TimePicker> = {
+    title: 'TimePicker',
+    component: TimePicker,
+    decorators: [
+        (Story) => (
+            <div style={{ maxWidth: '240px', padding: '24px' }}>
+                <Story />
+            </div>
+        ),
+    ],
+}
+
+// eslint-disable-next-line import/no-default-export
+export default meta
+
+type Story = StoryObj<typeof TimePicker>
+
+export const Default: Story = {}
+
+export const WithDefaultValue: Story = {
+    args: { value: '13:15' },
+}
+
+export const ThirtyMinuteIntervalWithRange: Story = {
+    args: { minutesInterval: 30, min: '09:00', max: '17:00' },
+}

--- a/packages/ui-extensions-react/src/components/time-picker/time-picker.test.tsx
+++ b/packages/ui-extensions-react/src/components/time-picker/time-picker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import { TimePicker } from './time-picker'
 
@@ -125,6 +125,19 @@ describe('TimePicker', () => {
             const select = screen.getByRole<HTMLSelectElement>('combobox')
 
             expect(select.value).toEqual('13:30')
+        })
+    })
+
+    describe('onTimeChange callback', () => {
+        it('calls onTimeChanged with the selected value when a new time is picked', () => {
+            const handleTimeChanged = jest.fn()
+            render(<TimePicker onTimeChanged={handleTimeChanged} minutesInterval={5} />)
+
+            const select = screen.getByRole<HTMLSelectElement>('combobox')
+            fireEvent.change(select, { target: { value: '13:15' } })
+
+            expect(select.value).toEqual('13:15')
+            expect(handleTimeChanged).toHaveBeenCalledWith('13:15')
         })
     })
 

--- a/packages/ui-extensions-react/src/components/time-picker/time-picker.tsx
+++ b/packages/ui-extensions-react/src/components/time-picker/time-picker.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import { DeprecatedSelect } from '@doist/reactist'
+import { SelectField } from '@doist/reactist'
 
 import classNames from 'classnames'
 import dayjs, { Dayjs } from 'dayjs'
@@ -47,11 +47,18 @@ export function TimePicker({
     return (
         <div className={classNames(styles.time_picker, className)}>
             <div data-testid="time-picker" className={classNames(styles.time_picker, className)}>
-                <DeprecatedSelect
-                    onChange={(time) => timeChanged(time)}
+                <SelectField
+                    label=""
+                    aria-label="Time"
                     defaultValue={defaultValue}
-                    options={times}
-                />
+                    onChange={(event) => timeChanged(event.target.value)}
+                >
+                    {times.map((time) => (
+                        <option key={time.value} value={time.value}>
+                            {time.text}
+                        </option>
+                    ))}
+                </SelectField>
             </div>
             <ClockIcon className={classNames(styles.time_picker, styles.svg_icon)} />
         </div>


### PR DESCRIPTION
## Overview

This PR migrates the `TimePicker` off the deprecated `DeprecatedSelect` to Reactist's `SelectField`, in preparation for [Reactist v33](https://github.com/Doist/reactist/releases/tag/v33.0.0) which removed it.

## Test plan

- Open Storybook and view the `TimePicker` stories (`Default`, `WithDefaultValue`, `ThirtyMinuteIntervalWithRange`):
  - [x] The field renders with the clock icon on the left and the selected time as text
  - [x] The right-side chevron (`˅`) is visible and sits above the select
  - [x] Opening the dropdown lists the expected times; `WithDefaultValue` preselects `13:15`
  - [x] Selecting a different time updates the displayed value
- [x] No extra vertical space appears where a label would be (`label=""` renders no label box)

## Demo

<table>
  <tr>
    <th>Before (<code>DeprecatedSelect</code>, native <code>⇅</code>)</th>
    <th>After (<code>SelectField</code>, chevron <code>˅</code>)</th>
  </tr>
  <tr>
    <td>
<img width="1049" height="303" alt="image" src="https://github.com/user-attachments/assets/9414ec05-2cb7-4d93-bc24-92383b28baec" />
</td>
    <td><img width="1051" height="319" alt="image" src="https://github.com/user-attachments/assets/b0611860-fa81-45a5-ac76-c0ba1d8cb202" /></td>
  </tr>
</table>
