### PR TITLE
Bump GitHub Action pins to node24-compatible majors

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,9 +6,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
 

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -11,10 +11,10 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Configure doist package repository
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
 

--- a/.github/workflows/core-deploy.yml
+++ b/.github/workflows/core-deploy.yml
@@ -20,10 +20,10 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Git checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Configure Doist package repository
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
                   registry-url: https://npm.pkg.github.com/
@@ -46,10 +46,10 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Git checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Configure Doist package repository
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
                   registry-url: https://registry.npmjs.org/

--- a/.github/workflows/react-ci.yml
+++ b/.github/workflows/react-ci.yml
@@ -11,10 +11,10 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Configure doist package repository
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
 

--- a/.github/workflows/react-deploy.yml
+++ b/.github/workflows/react-deploy.yml
@@ -12,10 +12,10 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Git checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Configure Doist package repository
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v6
               with:
                   node-version-file: '.nvmrc'
                   registry-url: https://npm.pkg.github.com/

--- a/.github/workflows/upload-schema.yml
+++ b/.github/workflows/upload-schema.yml
@@ -22,10 +22,10 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Git checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@v6
               with:
                   role-to-assume: arn:aws:iam::011833101604:role/doist-schemas-RoleCI-1P8IZE7IZUTXD
                   role-duration-seconds: 900


### PR DESCRIPTION
Bumps GitHub Action pins to majors that ship with the node24 runtime, ahead of GitHub's node20 deprecation.

- `actions/checkout` v4 → v6
- `actions/setup-node` v3 → v6
- `aws-actions/configure-aws-credentials` v4 → v6

Tracking: https://github.com/Doist/platform-backlog/issues/1385
