### PR TITLE
chore: Bump ui-extensions-react to v18.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27247,7 +27247,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "18.0.0",
+            "version": "18.1.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "2.5.1",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "18.0.0",
+    "version": "18.1.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",


### PR DESCRIPTION
We've updated Reactist to v34, but the changes don't impact ui-extensions-react

* https://github.com/Doist/ui-extensions/pull/311