### PR TITLE
feat!: require Reactist v36 and source colours from product-library tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2226,21 +2226,21 @@
             }
         },
         "node_modules/@doist/reactist": {
-            "version": "35.0.0",
-            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-35.0.0.tgz",
-            "integrity": "sha512-AZRQU7tdWGeCRrJ+flC2kmygxMoGEsrPl48leKHiAVk/axalFXU2ZDJYnZcgSnCBP9IGb/5WvfusTGDgdnpJ/A==",
+            "version": "36.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/reactist/-/reactist-36.0.0.tgz",
+            "integrity": "sha512-vYkoItwDJEanyn7isEIv8ZbSpoc4Uwb7BWzL2W40iRr72JmFakj4DvK3kQI849Ow1oVRI6lLOiw/m+jMG9oV4g==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.4",
-                "aria-hidden": "^1.2.1",
-                "dayjs": "^1.8.10",
-                "patch-package": "^6.4.6",
-                "react-focus-lock": "^2.9.1",
-                "react-keyed-flatten-children": "^1.3.0",
-                "react-markdown": "^5.0.3",
-                "use-callback-ref": "^1.3.0"
+                "@babel/runtime": "7.29.7",
+                "aria-hidden": "1.2.6",
+                "dayjs": "1.11.21",
+                "patch-package": "8.0.1",
+                "react-focus-lock": "2.13.7",
+                "react-keyed-flatten-children": "1.3.0",
+                "react-markdown": "5.0.3",
+                "use-callback-ref": "1.3.3"
             },
             "engines": {
                 "node": ">=24",
@@ -8266,6 +8266,8 @@
         },
         "node_modules/@yarnpkg/lockfile": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
             "dev": true,
             "license": "BSD-2-Clause"
         },
@@ -8845,14 +8847,6 @@
             "version": "0.4.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/at-least-node": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
         },
         "node_modules/atob": {
             "version": "2.1.2",
@@ -13580,6 +13574,8 @@
         },
         "node_modules/find-yarn-workspace-root": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -15390,22 +15386,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-ci": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ci-info": "^2.0.0"
-            },
-            "bin": {
-                "is-ci": "bin.js"
-            }
-        },
-        "node_modules/is-ci/node_modules/ci-info": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/is-core-module": {
             "version": "2.16.2",
             "license": "MIT",
@@ -17129,6 +17109,26 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/json-stable-stringify": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+            "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "isarray": "^2.0.5",
+                "jsonify": "^0.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "dev": true,
@@ -17159,6 +17159,16 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+            "dev": true,
+            "license": "Public Domain",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/jsx-ast-utils": {
@@ -17194,6 +17204,8 @@
         },
         "node_modules/klaw-sync": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18494,11 +18506,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/nice-try": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/no-case": {
             "version": "3.0.4",
             "dev": true,
@@ -19272,6 +19279,8 @@
         },
         "node_modules/open": {
             "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19356,14 +19365,6 @@
             "dev": true,
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/outvariant": {
             "version": "1.4.3",
@@ -19640,177 +19641,74 @@
             }
         },
         "node_modules/patch-package": {
-            "version": "6.5.1",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+            "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@yarnpkg/lockfile": "^1.1.0",
                 "chalk": "^4.1.2",
-                "cross-spawn": "^6.0.5",
+                "ci-info": "^3.7.0",
+                "cross-spawn": "^7.0.3",
                 "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^9.0.0",
-                "is-ci": "^2.0.0",
+                "fs-extra": "^10.0.0",
+                "json-stable-stringify": "^1.0.2",
                 "klaw-sync": "^6.0.0",
                 "minimist": "^1.2.6",
                 "open": "^7.4.2",
-                "rimraf": "^2.6.3",
-                "semver": "^5.6.0",
+                "semver": "^7.5.3",
                 "slash": "^2.0.0",
-                "tmp": "^0.0.33",
-                "yaml": "^1.10.2"
+                "tmp": "^0.2.4",
+                "yaml": "^2.2.2"
             },
             "bin": {
                 "patch-package": "index.js"
             },
             "engines": {
-                "node": ">=10",
+                "node": ">=14",
                 "npm": ">5"
             }
         },
-        "node_modules/patch-package/node_modules/balanced-match": {
-            "version": "1.0.2",
+        "node_modules/patch-package/node_modules/ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/patch-package/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
             "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/patch-package/node_modules/cross-spawn": {
-            "version": "6.0.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-            },
             "engines": {
-                "node": ">=4.8"
+                "node": ">=8"
             }
         },
         "node_modules/patch-package/node_modules/fs-extra": {
-            "version": "9.1.0",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/patch-package/node_modules/glob": {
-            "version": "7.2.3",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/patch-package/node_modules/minimatch": {
-            "version": "3.1.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/patch-package/node_modules/path-key": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/patch-package/node_modules/rimraf": {
-            "version": "2.7.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
-        "node_modules/patch-package/node_modules/semver": {
-            "version": "5.7.2",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/patch-package/node_modules/shebang-command": {
-            "version": "1.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "shebang-regex": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/patch-package/node_modules/shebang-regex": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
+                "node": ">=12"
             }
         },
         "node_modules/patch-package/node_modules/slash": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/patch-package/node_modules/which": {
-            "version": "1.3.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "which": "bin/which"
-            }
-        },
-        "node_modules/patch-package/node_modules/yaml": {
-            "version": "1.10.3",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/path-browserify": {
@@ -25216,14 +25114,13 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.0.33",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
             "engines": {
-                "node": ">=0.6.0"
+                "node": ">=14.14"
             }
         },
         "node_modules/tmpl": {
@@ -27617,7 +27514,7 @@
                 "@babel/preset-env": "7.29.7",
                 "@babel/preset-react": "7.29.7",
                 "@babel/preset-typescript": "7.29.7",
-                "@doist/reactist": "35.0.0",
+                "@doist/reactist": "36.0.0",
                 "@storybook/addon-actions": "7.6.24",
                 "@storybook/addon-essentials": "7.6.24",
                 "@storybook/addon-links": "7.6.24",
@@ -27642,7 +27539,7 @@
                 "npm": ">=11"
             },
             "peerDependencies": {
-                "@doist/reactist": "^32.0.0 || ^33.0.0 || ^34.0.0 || ^35.0.0",
+                "@doist/reactist": "^36.0.0",
                 "@doist/ui-extensions-core": "^5.0.0",
                 "adaptivecards": ">=2.9.0 <2.10.0",
                 "react": "^18.0.0",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -34,7 +34,7 @@
         "publish:yalc": "yalc push"
     },
     "peerDependencies": {
-        "@doist/reactist": "^32.0.0 || ^33.0.0 || ^34.0.0 || ^35.0.0",
+        "@doist/reactist": "^36.0.0",
         "@doist/ui-extensions-core": "^5.0.0",
         "adaptivecards": ">=2.9.0 <2.10.0",
         "react": "^18.0.0",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -51,7 +51,7 @@
         "@babel/preset-env": "7.29.7",
         "@babel/preset-react": "7.29.7",
         "@babel/preset-typescript": "7.29.7",
-        "@doist/reactist": "35.0.0",
+        "@doist/reactist": "36.0.0",
         "@storybook/addon-actions": "7.6.24",
         "@storybook/addon-essentials": "7.6.24",
         "@storybook/addon-links": "7.6.24",

--- a/packages/ui-extensions-react/src/components/doist-card.css
+++ b/packages/ui-extensions-react/src/components/doist-card.css
@@ -61,12 +61,12 @@
 
 .ac-anchor__attention {
     text-decoration: underline;
-    color: var(--reactist-actionable-destructive-idle-fill);
+    color: var(--product-library-actionable-destructive-idle-fill);
 }
 
 .ac-anchor__attention:hover {
     text-decoration: underline;
-    color: var(--reactist-actionable-destructive-hover-fill);
+    color: var(--product-library-actionable-destructive-hover-fill);
 }
 
 .ac-selectable {

--- a/packages/ui-extensions-react/src/components/time-picker/time-picker.module.css
+++ b/packages/ui-extensions-react/src/components/time-picker/time-picker.module.css
@@ -1,7 +1,7 @@
 :root {
     --time-picker-option-color: rgba(0, 0, 0, 0.88);
     --time-picker-option-background: rgb(255, 255, 255);
-    --time-picker-clock-color: var(--reactist-content-secondary);
+    --time-picker-clock-color: var(--product-library-display-secondary-idle-tint);
 }
 
 .time_picker {


### PR DESCRIPTION
## Overview

This PR brings in Reactist v36, which now includes the product library themes: https://github.com/Doist/reactist/releases/tag/v36.0.0.

With this change, we will only support `Reactist@^36.0.0`, as we now reference colour tokens that don't exist in older versions of Reactist.

## Reference

- https://github.com/Doist/reactist/pull/1094
