### PR TITLE
chore: Bump ui-extensions-react to v20.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27504,7 +27504,7 @@
         },
         "packages/ui-extensions-react": {
             "name": "@doist/ui-extensions-react",
-            "version": "19.0.0",
+            "version": "20.0.0",
             "license": "MIT",
             "dependencies": {
                 "classnames": "2.5.1",

--- a/packages/ui-extensions-react/package.json
+++ b/packages/ui-extensions-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/ui-extensions-react",
-    "version": "19.0.0",
+    "version": "20.0.0",
     "author": "Doist",
     "license": "MIT",
     "main": "dist/index.js",


### PR DESCRIPTION
## Overview

**Breaking change.** We now only support `@doist/reactist` `^36.0.0`. Our CSS reads `--product-library-*` colour tokens, which do not exist in Reactist v35 or earlier.

## Reference

- #321
- https://github.com/Doist/reactist/releases/tag/v36.0.0
